### PR TITLE
EquipmentConfig changes

### DIFF
--- a/Visualizer/Visualizer/BoundaryProcessor.cs
+++ b/Visualizer/Visualizer/BoundaryProcessor.cs
@@ -7,6 +7,7 @@
   *
   * Contributors:
   *    Tarak Reddy - initial implementation
+  *    Joseph Ross - Made changes to account for mapping multiple guidence patterns with the same context
   *******************************************************************************/
 
 using System.Linq;
@@ -30,15 +31,12 @@ namespace AgGateway.ADAPT.Visualizer
             using (var graphics = _spatialViewer.CreateGraphics())
             {
                 _drawingUtil = new DrawingUtil(_spatialViewer.Width, _spatialViewer.Height, graphics);
-
                 foreach (var polygon in fieldBoundary.SpatialData.Polygons)
                 {
                     var projectedPoints = polygon.ExteriorRing.Points.Select(point => point.ToUtm()).ToList();
-
-                    var delta = _drawingUtil.GetDelta(projectedPoints);
-                    _drawingUtil.SetOriginPoint(delta);
-
-                    var screenPolygon = projectedPoints.Select(point => point.ToXy(_drawingUtil.MinX, _drawingUtil.MinY, delta)).ToArray();
+                    _drawingUtil.SetMinMax(projectedPoints);
+                    
+                    var screenPolygon = projectedPoints.Select(point => point.ToXy(_drawingUtil.MinX, _drawingUtil.MinY, _drawingUtil.GetDelta())).ToArray();
 
                     graphics.DrawPolygon(DrawingUtil.Pen, screenPolygon);
                 }

--- a/Visualizer/Visualizer/GuidanceExtension.cs
+++ b/Visualizer/Visualizer/GuidanceExtension.cs
@@ -7,6 +7,7 @@
   *
   * Contributors:
   *    Tarak Reddy - initial implementation
+  *    Joseph Ross - Made changes to account for mapping multiple guidence patterns with the same context
   *******************************************************************************/
 
 using System;
@@ -19,28 +20,28 @@ namespace AgGateway.ADAPT.Visualizer
 {
     public static class GuidanceExtension
     {
-        public static double GetDelta(this APlus aPlus, DrawingUtil drawingUtil)
+        public static void SetMinMax(this APlus aPlus, DrawingUtil drawingUtil)
         {
             var points = new List<Point> {aPlus.Point.ToUtm()};
 
-            return GetDelta(drawingUtil, points);
+            SetMinMax(drawingUtil, points);
         }
 
-        public static double GetDelta(this AbLine abLine, DrawingUtil drawingUtil)
+        public static void SetMinMax(this AbLine abLine, DrawingUtil drawingUtil)
         {
             var points = new List<Point> {abLine.A.ToUtm(), abLine.B.ToUtm()};
 
-            return GetDelta(drawingUtil, points);
+            SetMinMax(drawingUtil, points);
         }
 
-        public static double GetDelta(this AbCurve abCurve, DrawingUtil drawingUtil)
+        public static void SetMinMax(this AbCurve abCurve, DrawingUtil drawingUtil)
         {
             var points = abCurve.Shape.SelectMany(x => x.Points).Select(x => x.ToUtm()).ToList();
 
-            return GetDelta(drawingUtil, points);
+            SetMinMax(drawingUtil, points);
         }
 
-        public static double GetDelta(this CenterPivot centerPivot, DrawingUtil drawingUtil)
+        public static void SetMinMax(this CenterPivot centerPivot, DrawingUtil drawingUtil)
         {
             var centerUtm = centerPivot.Center.ToUtm();
             var radius = Math.Abs(centerUtm.X - centerPivot.EndPoint.ToUtm().X);
@@ -74,28 +75,26 @@ namespace AgGateway.ADAPT.Visualizer
                 eastPoint
             };
 
-            return GetDelta(drawingUtil, points);
+            SetMinMax(drawingUtil, points);
         }
 
-        public static double GetDelta(this MultiAbLine multiAbLine, DrawingUtil drawingUtil)
+        public static void SetMinMax(this MultiAbLine multiAbLine, DrawingUtil drawingUtil)
         {
             var points = multiAbLine.AbLines.SelectMany(x => new List<Point> {x.A.ToUtm(), x.B.ToUtm()}).ToList();
 
-            return GetDelta(drawingUtil, points);
+            SetMinMax(drawingUtil, points);
         }
 
-        public static double GetDelta(this Spiral spiral, DrawingUtil drawingUtil)
+        public static void SetMinMax(this Spiral spiral, DrawingUtil drawingUtil)
         {
             var points = spiral.Shape.Points.Select(x => x.ToUtm()).ToList();
 
-            return GetDelta(drawingUtil, points);
+            SetMinMax(drawingUtil, points);
         }
 
-        private static double GetDelta(DrawingUtil drawingUtil, List<Point> points)
+        private static void SetMinMax(DrawingUtil drawingUtil, List<Point> points)
         {
-            var delta = drawingUtil.GetDelta(points);
-            drawingUtil.SetOriginPoint(delta);
-            return delta;
+            drawingUtil.SetMinMax(points);
         }
     }
 }

--- a/Visualizer/Visualizer/GuidanceProcessor.cs
+++ b/Visualizer/Visualizer/GuidanceProcessor.cs
@@ -7,6 +7,7 @@
   *
   * Contributors:
   *    Tarak Reddy - initial implementation
+  *    Joseph Ross - Made changes to account for mapping multiple guidence patterns with the same context
   *******************************************************************************/
 
 using System;
@@ -31,16 +32,23 @@ namespace AgGateway.ADAPT.Visualizer
 
         public void ProcessGuidance(GuidanceGroup guidanceGroup, List<GuidancePattern> guidancePatterns)
         {
-            foreach (var id in guidanceGroup.GuidancePatternIds)
+            using (var graphics = _spatialViewer.CreateGraphics())
             {
-                ProcessGuidancePattern(guidancePatterns, id);
+                _drawingUtil = new DrawingUtil(_spatialViewer.Width, _spatialViewer.Height, graphics);
+
+                SetMinMax(guidancePatterns, guidanceGroup.GuidancePatternIds);
+
+                foreach (var id in guidanceGroup.GuidancePatternIds)
+                {
+                    ProcessGuidancePattern(guidancePatterns, id);
+                }
             }
         }
 
         private void ProcessGuidancePattern(IEnumerable<GuidancePattern> guidancePatterns, int id)
         {
             var guidancePattern = guidancePatterns.First(pattern => pattern.Id.ReferenceId == id);
-            ProccessGuidancePattern(guidancePattern);
+            ProcessPattern(guidancePattern);
         }
 
         public void ProccessGuidancePattern(GuidancePattern guidancePattern)
@@ -49,43 +57,88 @@ namespace AgGateway.ADAPT.Visualizer
             {
                 _drawingUtil = new DrawingUtil(_spatialViewer.Width, _spatialViewer.Height, graphics);
 
-                if (guidancePattern is APlus)
-                {
-                    ProcessAPlus(guidancePattern as APlus);
-                }
-                else if (guidancePattern is AbLine)
-                {
-                    ProcessAbLine(guidancePattern as AbLine);
-                }
-                else if (guidancePattern is AbCurve)
-                {
-                    ProcessAbCurve(guidancePattern as AbCurve);
-                }
-                else if (guidancePattern is CenterPivot)
-                {
-                    ProcessCenterPivot(guidancePattern as CenterPivot);
-                }
-                else if (guidancePattern is MultiAbLine)
-                {
-                    ProcessMultiAbLine(guidancePattern as MultiAbLine);
-                }
-                else if (guidancePattern is Spiral)
-                {
-                    ProcessSpiral(guidancePattern as Spiral);
-                }
+                SetMinMax(guidancePattern);
+
+                ProcessPattern(guidancePattern);
+            }
+        }
+
+        private void SetMinMax(IEnumerable<GuidancePattern> guidancePatterns, List<int> guidancePatternIds)
+        {
+            var matchingGuidancePatterns = guidancePatterns.Where(pattern => guidancePatternIds.Contains(pattern.Id.ReferenceId));
+
+            foreach (var guidancePattern in matchingGuidancePatterns)
+            {
+                SetMinMax(guidancePattern);
+            }
+        }
+
+        private void SetMinMax(GuidancePattern guidancePattern)
+        {
+            if (guidancePattern is APlus)
+            {
+                (guidancePattern as APlus).SetMinMax(_drawingUtil);
+            }
+            else if (guidancePattern is AbLine)
+            {
+                (guidancePattern as AbLine).SetMinMax(_drawingUtil);
+            }
+            else if (guidancePattern is AbCurve)
+            {
+                (guidancePattern as AbCurve).SetMinMax(_drawingUtil);
+            }
+            else if (guidancePattern is CenterPivot)
+            {
+                (guidancePattern as CenterPivot).SetMinMax(_drawingUtil);
+            }
+            else if (guidancePattern is MultiAbLine)
+            {
+                (guidancePattern as MultiAbLine).SetMinMax(_drawingUtil);
+            }
+            else if (guidancePattern is Spiral)
+            {
+                (guidancePattern as Spiral).SetMinMax(_drawingUtil);
+            }
+        }
+
+        private void ProcessPattern(GuidancePattern guidancePattern)
+        {
+            if (guidancePattern is APlus)
+            {
+                ProcessAPlus(guidancePattern as APlus);
+            }
+            else if (guidancePattern is AbLine)
+            {
+                ProcessAbLine(guidancePattern as AbLine);
+            }
+            else if (guidancePattern is AbCurve)
+            {
+                ProcessAbCurve(guidancePattern as AbCurve);
+            }
+            else if (guidancePattern is CenterPivot)
+            {
+                ProcessCenterPivot(guidancePattern as CenterPivot);
+            }
+            else if (guidancePattern is MultiAbLine)
+            {
+                ProcessMultiAbLine(guidancePattern as MultiAbLine);
+            }
+            else if (guidancePattern is Spiral)
+            {
+                ProcessSpiral(guidancePattern as Spiral);
             }
         }
 
         private void ProcessSpiral(Spiral spiral)
         {
-            var delta = spiral.GetDelta(_drawingUtil);
+            var delta = _drawingUtil.GetDelta();
 
             ProcessLineString(spiral.Shape, delta);
         }
 
         private void ProcessMultiAbLine(MultiAbLine multiAbLine)
         {
-            var delta = multiAbLine.GetDelta(_drawingUtil);
+            var delta = _drawingUtil.GetDelta();
 
             foreach (var abLine in multiAbLine.AbLines)
             {
@@ -95,7 +148,7 @@ namespace AgGateway.ADAPT.Visualizer
 
         private void ProcessCenterPivot(CenterPivot centerPivot)
         {
-            var delta = centerPivot.GetDelta(_drawingUtil);
+            var delta = _drawingUtil.GetDelta();
             var center = centerPivot.Center.ToUtm().ToXy(_drawingUtil.MinX, _drawingUtil.MinY, delta);
             var radius = GetRadius(centerPivot);
             _drawingUtil.Graphics.DrawEllipse(DrawingUtil.Pen, center.X - radius, center.Y - radius, radius + radius, radius + radius);
@@ -110,7 +163,7 @@ namespace AgGateway.ADAPT.Visualizer
 
         private void ProcessAbCurve(AbCurve abCurve)
         {
-            var delta = abCurve.GetDelta(_drawingUtil);
+            var delta = _drawingUtil.GetDelta();
 
             foreach (var lineString in abCurve.Shape)
             {
@@ -120,14 +173,14 @@ namespace AgGateway.ADAPT.Visualizer
 
         private void ProcessAbLine(AbLine abLine)
         {
-            var delta = abLine.GetDelta(_drawingUtil);
+            var delta = _drawingUtil.GetDelta();
 
             ProcessPoints(new List<Point> {abLine.A, abLine.B}, delta);
         }
 
         private void ProcessAPlus(APlus aPlus)
         {
-            var delta = aPlus.GetDelta(_drawingUtil);
+            var delta = _drawingUtil.GetDelta();
             var projectedPoint = aPlus.Point;
         }
 

--- a/Visualizer/Visualizer/MainForm.Designer.cs
+++ b/Visualizer/Visualizer/MainForm.Designer.cs
@@ -48,6 +48,7 @@
             this._tabControlViewer = new System.Windows.Forms.TabControl();
             this._tabPageSpatial = new System.Windows.Forms.TabPage();
             this._tabPageRawData = new System.Windows.Forms.TabPage();
+            this._buttonExportRawData = new System.Windows.Forms.Button();
             this._dataGridViewRawData = new System.Windows.Forms.DataGridView();
             this._dataGridViewTotals = new System.Windows.Forms.DataGridView();
             this._dataGridColumnDescription = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -60,7 +61,6 @@
             this._buttonBrowseExportPath = new System.Windows.Forms.Button();
             this._textBoxExportPath = new System.Windows.Forms.TextBox();
             this._labelPath = new System.Windows.Forms.Label();
-            this._buttonExportRawData = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this._splitContainerMain)).BeginInit();
             this._splitContainerMain.Panel1.SuspendLayout();
             this._splitContainerMain.Panel2.SuspendLayout();
@@ -333,6 +333,17 @@
             this._tabPageRawData.Text = "Raw data Viewer";
             this._tabPageRawData.UseVisualStyleBackColor = true;
             // 
+            // _buttonExportRawData
+            // 
+            this._buttonExportRawData.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this._buttonExportRawData.Location = new System.Drawing.Point(439, 321);
+            this._buttonExportRawData.Name = "_buttonExportRawData";
+            this._buttonExportRawData.Size = new System.Drawing.Size(89, 23);
+            this._buttonExportRawData.TabIndex = 1;
+            this._buttonExportRawData.Text = "Export";
+            this._buttonExportRawData.UseVisualStyleBackColor = true;
+            this._buttonExportRawData.Click += new System.EventHandler(this._buttonExportRawData_Click);
+            // 
             // _dataGridViewRawData
             // 
             this._dataGridViewRawData.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
@@ -450,17 +461,6 @@
             this._labelPath.Size = new System.Drawing.Size(62, 13);
             this._labelPath.TabIndex = 0;
             this._labelPath.Text = "Export Path";
-            // 
-            // _buttonExportRawData
-            // 
-            this._buttonExportRawData.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this._buttonExportRawData.Location = new System.Drawing.Point(439, 321);
-            this._buttonExportRawData.Name = "_buttonExportRawData";
-            this._buttonExportRawData.Size = new System.Drawing.Size(89, 23);
-            this._buttonExportRawData.TabIndex = 1;
-            this._buttonExportRawData.Text = "Export";
-            this._buttonExportRawData.UseVisualStyleBackColor = true;
-            this._buttonExportRawData.Click += new System.EventHandler(this._buttonExportRawData_Click);
             // 
             // MainForm
             // 

--- a/Visualizer/Visualizer/MainForm.cs
+++ b/Visualizer/Visualizer/MainForm.cs
@@ -201,7 +201,7 @@ namespace AgGateway.ADAPT.Visualizer
 
             var propertyValue = propertyInfo.GetIndexParameters().Any() ? null : propertyInfo.GetValue(element, null);
 
-            if (propertyType.IsPrimitive || propertyType == typeof (string) || propertyType == typeof (DateTime))
+            if (propertyType.IsPrimitive || propertyType == typeof (string) || propertyType == typeof (DateTime) || propertyType.IsEnum)
             {
                 parentNode.Nodes.Add(string.Format(@"{0}: {1}", propertyInfo.Name, propertyValue));
             }

--- a/Visualizer/Visualizer/MainForm.cs
+++ b/Visualizer/Visualizer/MainForm.cs
@@ -188,7 +188,7 @@ namespace AgGateway.ADAPT.Visualizer
 
         private void ParseProperty(object element, TreeNode parentNode, PropertyInfo propertyInfo)
         {
-            if (element is Func<object> || element is Func<int, object>)
+            if (element is Func<object> || element is Func<int, object> || element is Meter || element is Section || element is DataLogTrigger)
                 return;
 
             var propertyType = propertyInfo.PropertyType;

--- a/Visualizer/VisualizerTests/DrawingUtilTest.cs
+++ b/Visualizer/VisualizerTests/DrawingUtilTest.cs
@@ -1,0 +1,98 @@
+﻿using System.Collections.Generic;
+using System.Drawing;
+using System.Windows.Forms;
+using AgGateway.ADAPT.Visualizer;
+using NUnit.Framework;
+using Point = AgGateway.ADAPT.ApplicationDataModel.Shapes.Point;
+
+namespace VisualizerTests
+{
+    [TestFixture]
+    public class DrawingUtilTest
+    {
+        private DrawingUtil _drawingUtil;
+        private Graphics _graphics;
+        private TabPage _tabPage;
+
+        [SetUp]
+        public void Setup()
+        {
+            _tabPage = new TabPage();
+            _graphics = _tabPage.CreateGraphics();
+            _drawingUtil = new DrawingUtil(1050, 1050, _graphics);
+        }
+
+        [Test]
+        public void GivenListOfPointsWhenSetMinAndMaxThenMinIsSet()
+        {
+            var points = new List<Point>();
+            points.Add(new Point { X = 5600, Y = 8900});
+            points.Add(new Point { X = 3600, Y = 7200 });
+            points.Add(new Point { X = 9900, Y = 1000 });
+            points.Add(new Point { X = 7600, Y = 2200 });
+            points.Add(new Point { X = 2000, Y = 9000 });
+
+            _drawingUtil.SetMinMax(points);
+            Assert.AreEqual(_drawingUtil.MinX, 2000.0);
+            Assert.AreEqual(_drawingUtil.MinY, 1000.0);
+            Assert.AreEqual(_drawingUtil.MaxX, 9900.0);
+            Assert.AreEqual(_drawingUtil.MaxY, 9000.0);
+        }
+
+        [Test]
+        public void GivenMinAndMaxesSetAndWidthAndHeightAreEqualWhenGetDeltaThenDeltaIsReturned()
+        {
+            var points = new List<Point>();
+            points.Add(new Point { X = 5600, Y = 8900 });
+            points.Add(new Point { X = 3600, Y = 7200 });
+            points.Add(new Point { X = 9900, Y = 1000 });
+            points.Add(new Point { X = 7600, Y = 2200 });
+            points.Add(new Point { X = 2000, Y = 9000 });
+            _drawingUtil.SetMinMax(points);
+
+            var delta = _drawingUtil.GetDelta();
+            Assert.AreEqual(8, delta);
+        }
+
+        [Test]
+        public void GivenMinAndMaxesSetAndHeightAndLatisGreaterWhenGetDeltaThenDeltaIsReturned()
+        {
+            _drawingUtil = new DrawingUtil(1050, 1650, _graphics);
+
+            var points = new List<Point>();
+            points.Add(new Point { X = 5600, Y = 8900 });
+            points.Add(new Point { X = 3600, Y = 7200 });
+            points.Add(new Point { X = 9000, Y = 1000 });
+            points.Add(new Point { X = 7600, Y = 2200 });
+            points.Add(new Point { X = 3000, Y = 9000 });
+            _drawingUtil.SetMinMax(points);
+
+            var delta = _drawingUtil.GetDelta();
+            Assert.AreEqual(6, delta);
+        }
+
+        [Test]
+        public void GivenMinAndMaxesSetAndHeightAndLonAreGreaterWhenGetDeltaThenDeltaIsReturned()
+        {
+            _drawingUtil = new DrawingUtil(600, 1050, _graphics);
+
+            var points = new List<Point>();
+            points.Add(new Point { X = 5600, Y = 9000 });
+            points.Add(new Point { X = 3600, Y = 7200 });
+            points.Add(new Point { X = 9000, Y = 2000 });
+            points.Add(new Point { X = 7600, Y = 2700 });
+            points.Add(new Point { X = 1000, Y = 8000 });
+            _drawingUtil.SetMinMax(points);
+
+            var delta = _drawingUtil.GetDelta();
+            Assert.AreEqual(7, delta);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _tabPage.Dispose();
+            _graphics.Dispose();
+        }
+    }
+}

--- a/Visualizer/VisualizerTests/VisualizerTests.csproj
+++ b/Visualizer/VisualizerTests/VisualizerTests.csproj
@@ -48,6 +48,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -55,6 +57,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DrawingUtilTest.cs" />
     <Compile Include="OperationDatProcessorTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/source/ADAPT/Equipment/EquipmentConfig.cs
+++ b/source/ADAPT/Equipment/EquipmentConfig.cs
@@ -8,6 +8,7 @@
   *
   * Contributors:
   *    Tarak Reddy, Tim Shearouse - initial API and implementation    
+  *    Kathleen Oneal - changed lists to ienumerables for effeciency  
   *******************************************************************************/
 
 using System.Collections.Generic;
@@ -31,10 +32,10 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Equipment
 
         public int? ImplementConfigurationId { get; set; }
 
-        public List<Meter> Meters { get; set; }
+        public IEnumerable<Meter> Meters { get; set; }
 
-        public List<Section> Sections { get; set; }
+        public IEnumerable<Section> Sections { get; set; }
 
-        public List<DataLogTrigger> Triggers { get; set; }
+        public IEnumerable<DataLogTrigger> Triggers { get; set; }
     }
 }

--- a/source/ADAPT/ReferenceLayers/ReferenceLayer.cs
+++ b/source/ADAPT/ReferenceLayers/ReferenceLayer.cs
@@ -36,7 +36,5 @@ namespace AgGateway.ADAPT.ApplicationDataModel.ReferenceLayers
         public Polygon BoundingPolygon { get; set; }
 
         public List<ContextItem> ContextItems { get; set; }
-
-        public List<int> FieldIds { get; set; }
     }
 }

--- a/source/ADAPT/ReferenceLayers/ReferenceLayer.cs
+++ b/source/ADAPT/ReferenceLayers/ReferenceLayer.cs
@@ -14,6 +14,7 @@
 
 using System.Collections.Generic;
 using AgGateway.ADAPT.ApplicationDataModel.Common;
+using AgGateway.ADAPT.ApplicationDataModel.Logistics;
 using AgGateway.ADAPT.ApplicationDataModel.Shapes;
 
 namespace AgGateway.ADAPT.ApplicationDataModel.ReferenceLayers
@@ -36,5 +37,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.ReferenceLayers
         public Polygon BoundingPolygon { get; set; }
 
         public List<ContextItem> ContextItems { get; set; }
+
+        public Field Field { get; set; }
     }
 }

--- a/source/ADAPT/ReferenceLayers/ReferenceLayer.cs
+++ b/source/ADAPT/ReferenceLayers/ReferenceLayer.cs
@@ -14,7 +14,6 @@
 
 using System.Collections.Generic;
 using AgGateway.ADAPT.ApplicationDataModel.Common;
-using AgGateway.ADAPT.ApplicationDataModel.Logistics;
 using AgGateway.ADAPT.ApplicationDataModel.Shapes;
 
 namespace AgGateway.ADAPT.ApplicationDataModel.ReferenceLayers
@@ -38,6 +37,6 @@ namespace AgGateway.ADAPT.ApplicationDataModel.ReferenceLayers
 
         public List<ContextItem> ContextItems { get; set; }
 
-        public Field Field { get; set; }
+        public List<int> FieldIds { get; set; }
     }
 }

--- a/source/Representation/RepresentationSystem/EnumeratedRepresentation.cs
+++ b/source/Representation/RepresentationSystem/EnumeratedRepresentation.cs
@@ -33,6 +33,8 @@ namespace AgGateway.ADAPT.Representation.RepresentationSystem
             var name = GetName(enumeratedRepresentation.Name, culture);
             Name = name != null ? name.Value : null;
             Description = name != null ? name.description : null;
+            if (enumeratedRepresentation.RelatedDDI != null)
+                Ddi = enumeratedRepresentation.RelatedDDI[0].ddi;
         }
 
         private static RepresentationCollection<EnumerationMember> GetEnumerationMembers(RepresentationSystemRepresentationsEnumeratedRepresentation enumeratedRepresentation)

--- a/source/Representation/RepresentationSystem/ExtensionMethods/RepresentationExtensions.cs
+++ b/source/Representation/RepresentationSystem/ExtensionMethods/RepresentationExtensions.cs
@@ -10,6 +10,7 @@
   *    Tarak Reddy, Tim Shearouse - initial API and implementation
   *******************************************************************************/
 using System.Linq;
+using AgGateway.ADAPT.ApplicationDataModel.Common;
 using AgGateway.ADAPT.ApplicationDataModel.Representations;
 
 namespace AgGateway.ADAPT.Representation.RepresentationSystem.ExtensionMethods
@@ -18,24 +19,41 @@ namespace AgGateway.ADAPT.Representation.RepresentationSystem.ExtensionMethods
    {
       public static ApplicationDataModel.Representations.NumericRepresentation ToModelRepresentation(this NumericRepresentation representation)
       {
-         return new ApplicationDataModel.Representations.NumericRepresentation
-         {
-            Code = representation.DomainId,
-            Description = representation.Description,
-         };
+          var numericRepresentation = new ApplicationDataModel.Representations.NumericRepresentation
+          {
+              Code = representation.DomainId,
+              Description = representation.Description,
+          };
+          numericRepresentation.Id.UniqueIds.Add(new UniqueId
+          {
+              Id = representation.DomainId,
+              CiTypeEnum = CompoundIdentifierTypeEnum.LongInt,
+              Source = "http://dictionary.isobus.net/isobus/",
+              SourceType = IdSourceTypeEnum.URI
+          });
+
+          return numericRepresentation;
       }
 
-      public static ApplicationDataModel.Representations.EnumeratedRepresentation ToModelRepresentation(this EnumeratedRepresentation representation)
+       public static ApplicationDataModel.Representations.EnumeratedRepresentation ToModelRepresentation(this EnumeratedRepresentation representation)
       {
-         return new ApplicationDataModel.Representations.EnumeratedRepresentation
-         {
-            Code = representation.DomainId,
-            Description = representation.Description,
-            EnumeratedMembers = representation.EnumerationMembers.Select(m => m.ToModelEnumMember()).ToList()
-         };
+          var enumeratedRepresentation = new ApplicationDataModel.Representations.EnumeratedRepresentation
+          {
+              Code = representation.DomainId,
+              Description = representation.Description,
+              EnumeratedMembers = representation.EnumerationMembers.Select(m => m.ToModelEnumMember()).ToList(),
+          };
+          enumeratedRepresentation.Id.UniqueIds.Add(new UniqueId
+          {
+              Id = representation.DomainId,
+              CiTypeEnum = CompoundIdentifierTypeEnum.LongInt,
+              Source = "http://dictionary.isobus.net/isobus/",
+              SourceType = IdSourceTypeEnum.URI
+          });
+          return enumeratedRepresentation;
       }
 
-      public static ApplicationDataModel.Representations.EnumerationMember ToModelEnumMember(this EnumerationMember enumMember)
+       public static ApplicationDataModel.Representations.EnumerationMember ToModelEnumMember(this EnumerationMember enumMember)
       {
          return new ApplicationDataModel.Representations.EnumerationMember
          {

--- a/source/Representation/RepresentationSystem/NumericRepresentation.cs
+++ b/source/Representation/RepresentationSystem/NumericRepresentation.cs
@@ -56,6 +56,8 @@ namespace AgGateway.ADAPT.Representation.RepresentationSystem
             Name = name != null ? name.Value : null;
             Description = name != null ? name.description : null;
             UnitDimension = FindUnitDimension(representation);
+            if(representation.RelatedDDI != null)
+                Ddi = representation.RelatedDDI[0].ddi;
 
             _unitOfMeasureDefaults = GetDefaultUnitOfMeasures(representation.Items);
             _unitOfMeasurePreferences = GetUnitOfMeasurePreferences(representation.Items);

--- a/source/Representation/RepresentationSystem/Representation.cs
+++ b/source/Representation/RepresentationSystem/Representation.cs
@@ -17,6 +17,7 @@ namespace AgGateway.ADAPT.Representation.RepresentationSystem
         public long DomainTag { get; protected set; }
         public string Name { get; protected set; }
         public string Description { get; protected set; }
+        public int? Ddi { get; protected set; }
 
         protected Representation(string domainId, long domainTag)
         {


### PR DESCRIPTION
Changed the properties sections, meters, and datalogtriggers from Lists to IEnumerables.
Made a fix in Visualizer. Large cards were getting "out of memory" exceptions because it was trying to load the list of sections, meters, and triggers on EquipmentConfig in the tree node. These 3 properties values no longer show in the tree node.