### PR TITLE
Change NuGet source to v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
         - VERSION=$(echo $TRAVIS_TAG | grep -i -P -o '(?<=^v)\d+\.\d+\.\d+(?:.+)?$'); VERSION_NUMBER=$(echo $VERSION | grep -i -P -o '^\d+\.\d+\.\d+')
         - dotnet build ./ADAPT.sln -c Release /p:Version=$VERSION /p:FileVersion=$VERSION_NUMBER.$TRAVIS_BUILD_NUMBER
         - mkdir -p ./dist; nuget pack ./AgGatewayADAPTFramework.nuspec -verbosity detailed -outputdirectory ./dist -version $VERSION
-        - if [ -n "${NUGET_API_KEY}" ]; then nuget push ./dist/AgGatewayADAPTFramework.${VERSION}.nupkg -apikey $NUGET_API_KEY -source https://api.nuget.org/v3/index.json; fi
+        - if [ -n "${NUGET_API_KEY}" ]; then nuget push ./dist/AgGatewayADAPTFramework.${VERSION}.nupkg -apikey $NUGET_API_KEY -source https://www.nuget.org/api/v2/package; fi
       deploy:
         provider: releases
         api_key: $GITHUB_OAUTH_TOKEN


### PR DESCRIPTION
I'm not sure if this is the solution as the existing code to publish to NuGet work fine on my machine but when it does work it uses the source I've updated Travis CI to use.