### PR TITLE
Additions to the model based on Issues 163, 146, 144, 138

### DIFF
--- a/source/ADAPT/Common/OperationTypeEnum.cs
+++ b/source/ADAPT/Common/OperationTypeEnum.cs
@@ -9,6 +9,7 @@
   * Contributors:
   *    Tarak Reddy, Tim Shearouse - initial API and implementation
   *    Kathleen Oneal - added values
+  *    Jason Roesbeke - added Irrigation
   *******************************************************************************/  
 
 namespace AgGateway.ADAPT.ApplicationDataModel.Common

--- a/source/ADAPT/Common/OperationTypeEnum.cs
+++ b/source/ADAPT/Common/OperationTypeEnum.cs
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
   * Copyright (C) 2015 AgGateway and ADAPT Contributors
   * Copyright (C) 2015 Deere and Company
   * All rights reserved. This program and the accompanying materials
@@ -26,6 +26,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Common
         Harvesting,
         ForageHarvesting,
         Transport,
-        Swathing
+        Swathing,
+        Irrigation
     }
 }

--- a/source/ADAPT/Documents/OperationSummary.cs
+++ b/source/ADAPT/Documents/OperationSummary.cs
@@ -9,6 +9,7 @@
   * Contributors:
   *    Jospeh Ross - creating class
   *	   Stuart Rhea - Added ContextItems per model.
+  *	   Jason Roesbeke - added Description
   *******************************************************************************/
 
 using System.Collections.Generic;

--- a/source/ADAPT/Documents/OperationSummary.cs
+++ b/source/ADAPT/Documents/OperationSummary.cs
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
   * Copyright (C) 2015 AgGateway and ADAPT Contributors
   * Copyright (C) 2015 Deere and Company
   * All rights reserved. This program and the accompanying materials
@@ -41,5 +41,8 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Documents
         public MultiPolygon CoverageShape { get; set; }
 
         public List<ContextItem> ContextItems { get; set; }
+
+        public string Description { get; set; }
+
     }
 }

--- a/source/ADAPT/LoggedData/OperationData.cs
+++ b/source/ADAPT/LoggedData/OperationData.cs
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
   * Copyright (C) 2015-16 AgGateway and ADAPT Contributors
   * Copyright (C) 2015-16 Deere and Company
   * All rights reserved. This program and the accompanying materials
@@ -51,5 +51,8 @@ namespace AgGateway.ADAPT.ApplicationDataModel.LoggedData
         public Func<IEnumerable<SpatialRecord>> GetSpatialRecords { get; set; }
 
         public Func<int, IEnumerable<DeviceElementUse>> GetDeviceElementUses { get; set; }
+
+        public string Description { get; set; }
+
     }
 }

--- a/source/ADAPT/LoggedData/OperationData.cs
+++ b/source/ADAPT/LoggedData/OperationData.cs
@@ -11,6 +11,7 @@
   *    Kathleen Oneal - removed implementConfigId and machineConfigId, added EquipmentConfigId
   *    Justin Sliekers - implement device element changes
   *    Joseph Ross - Added EquipmentConfigurationGroup
+  *	   Jason Roesbeke - added Description    
   *******************************************************************************/
 
 using System;

--- a/source/ADAPT/Logistics/GpsSourceEnum.cs
+++ b/source/ADAPT/Logistics/GpsSourceEnum.cs
@@ -8,6 +8,7 @@
   *
   * Contributors:
   *    Tarak Reddy, Tim Shearouse - initial API and implementation
+  *    Jason Roesbeke - Added PPP & SBAS
   *******************************************************************************/  
 
 namespace AgGateway.ADAPT.ApplicationDataModel.Logistics

--- a/source/ADAPT/Logistics/GpsSourceEnum.cs
+++ b/source/ADAPT/Logistics/GpsSourceEnum.cs
@@ -24,15 +24,15 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Logistics
         DeereWAAS,
         GNSSfix,
         DGNSSfix,
-        PPP, //Precise Point Positioning
         PreciseGNSS,
         RTKFixedInteger,
         RTKFloat,
         EstDRmode,
         ManualInput,
-        SBAS, //Satellite Based Augmentation System
         SimulateMode,
         DesktopGeneratedData,
-        Other
+        Other,
+        PPP, //Precise Point Positioning
+        SBAS, //Satellite Based Augmentation System
     }
 }

--- a/source/ADAPT/Logistics/GpsSourceEnum.cs
+++ b/source/ADAPT/Logistics/GpsSourceEnum.cs
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
   * Copyright (C) 2015 AgGateway and ADAPT Contributors
   * Copyright (C) 2015 Deere and Company
   * All rights reserved. This program and the accompanying materials
@@ -24,11 +24,13 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Logistics
         DeereWAAS,
         GNSSfix,
         DGNSSfix,
+        PPP, //Precise Point Positioning
         PreciseGNSS,
         RTKFixedInteger,
         RTKFloat,
         EstDRmode,
         ManualInput,
+        SBAS, //Satellite Based Augmentation System
         SimulateMode,
         DesktopGeneratedData,
         Other

--- a/source/ADAPT/Prescriptions/Prescription.cs
+++ b/source/ADAPT/Prescriptions/Prescription.cs
@@ -12,6 +12,7 @@
 
 using System.Collections.Generic;
 using AgGateway.ADAPT.ApplicationDataModel.Common;
+using AgGateway.ADAPT.ApplicationDataModel.Logistics;
 
 namespace AgGateway.ADAPT.ApplicationDataModel.Prescriptions
 {
@@ -24,6 +25,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Prescriptions
             ProductIds = new List<int>();
             ContextItems = new List<ContextItem>();
             TimeScopes = new List<TimeScope>();
+            PersonRoles = new List<PersonRole>();
         }
 
         public CompoundIdentifier Id { get; private set; }
@@ -43,6 +45,8 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Prescriptions
         public List<ContextItem> ContextItems { get; set; }
 
         public List<TimeScope> TimeScopes { get; set; }
+
+        public List<PersonRole> PersonRoles { get; set; }
 
     }
 }

--- a/source/ADAPT/Prescriptions/Prescription.cs
+++ b/source/ADAPT/Prescriptions/Prescription.cs
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
   * Copyright (C) 2015 AgGateway and ADAPT Contributors
   * Copyright (C) 2015 Deere and Company
   * All rights reserved. This program and the accompanying materials
@@ -23,6 +23,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Prescriptions
             RxProductLookups = new List<RxProductLookup>();
             ProductIds = new List<int>();
             ContextItems = new List<ContextItem>();
+            TimeScopes = new List<TimeScope>();
         }
 
         public CompoundIdentifier Id { get; private set; }
@@ -40,5 +41,8 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Prescriptions
         public List<int> ProductIds { get; set; }
 
         public List<ContextItem> ContextItems { get; set; }
+
+        public List<TimeScope> TimeScopes { get; set; }
+
     }
 }

--- a/source/ADAPT/Prescriptions/Prescription.cs
+++ b/source/ADAPT/Prescriptions/Prescription.cs
@@ -8,6 +8,7 @@
   *
   * Contributors:
   *    Justin Sliekers - initial API and implementation
+  *    Jason Roesbeke - Added a list with TimeScopes and a list with Personroles
   *******************************************************************************/
 
 using System.Collections.Generic;

--- a/source/ADAPT/Prescriptions/RasterGridPrescription.cs
+++ b/source/ADAPT/Prescriptions/RasterGridPrescription.cs
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
   * Copyright (C) 2015 AgGateway and ADAPT Contributors
   * Copyright (C) 2015 Deere and Company
   * All rights reserved. This program and the accompanying materials
@@ -21,7 +21,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Prescriptions
    {
        public RasterGridPrescription()
        {
-           Rates = new List<RxRates>();
+           Rates = new List<RxCellLookup>();
        }
 
       public Point Origin { get; set; }
@@ -34,6 +34,6 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Prescriptions
 
       public NumericRepresentationValue CellHeight { get; set; }
 
-      public List<RxRates> Rates { get; set; }
+      public List<RxCellLookup> Rates { get; set; }
    }
 }

--- a/source/ADAPT/Prescriptions/RasterGridPrescription.cs
+++ b/source/ADAPT/Prescriptions/RasterGridPrescription.cs
@@ -9,6 +9,7 @@
   * Contributors:
   *    Justin Sliekers - initial API and implementation
   *    Justin Sliekers - removing all properties
+  *    Jason Roesbeke - changed List<RxRates> to List<RxCellLookup> because the class name has been changed
   *******************************************************************************/
 
 using System.Collections.Generic;

--- a/source/ADAPT/Prescriptions/RxCellLookup .cs
+++ b/source/ADAPT/Prescriptions/RxCellLookup .cs
@@ -8,6 +8,7 @@
   *
   * Contributors:
   *    Justin Sliekers - initial API and implementation
+  *    Jason Roesbeke - Changed class name from RxRates to RxCellLookup 
   *******************************************************************************/
 
 using System.Collections.Generic;

--- a/source/ADAPT/Prescriptions/RxCellLookup .cs
+++ b/source/ADAPT/Prescriptions/RxCellLookup .cs
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
   * Copyright (C) 2015 AgGateway and ADAPT Contributors
   * Copyright (C) 2015 Deere and Company
   * All rights reserved. This program and the accompanying materials
@@ -14,13 +14,13 @@ using System.Collections.Generic;
 
 namespace AgGateway.ADAPT.ApplicationDataModel.Prescriptions
 {
-    public class RxRates
+    public class RxCellLookup
     {
-        public RxRates()
+        public RxCellLookup()
         {
-            RxRate = new List<RxRate>();
+            RxRates = new List<RxRate>();
         }
 
-        public List<RxRate> RxRate { get; set; } 
+        public List<RxRate> RxRates { get; set; } 
     }
 }

--- a/source/ADAPT/Products/CategoryEnum.cs
+++ b/source/ADAPT/Products/CategoryEnum.cs
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
   * Copyright (C) 2015 AgGateway and ADAPT Contributors
   * Copyright (C) 2015 Deere and Company
   * All rights reserved. This program and the accompanying materials
@@ -22,12 +22,14 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Products
     {
         Additive,
         Carrier,
+        Fertilizer, //non-manure
         Fungicide,
         GrowthRegulator,
         Insecticide,
         Herbicide,
         Manure,
         NitrogenStabilizer,
+        Pesticide, //non-Insecticide
         Unknown,
         Variety,
     }

--- a/source/ADAPT/Products/CategoryEnum.cs
+++ b/source/ADAPT/Products/CategoryEnum.cs
@@ -22,15 +22,15 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Products
     {
         Additive,
         Carrier,
-        Fertilizer, //non-manure
         Fungicide,
         GrowthRegulator,
         Insecticide,
         Herbicide,
         Manure,
         NitrogenStabilizer,
-        Pesticide, //non-Insecticide
         Unknown,
         Variety,
+        Fertilizer, //non-manure
+        Pesticide, //non-Insecticide
     }
 }

--- a/source/ADAPT/Products/CategoryEnum.cs
+++ b/source/ADAPT/Products/CategoryEnum.cs
@@ -14,6 +14,7 @@
   *    Kathleen Oneal - added variety value
   *    Kathleen Oneal - added Additive, GrowthRegulator, Insecticide, and NitrogenStabilizer values
   *    Kathleen Oneal - added Carrier
+  *    Jason Roesbeke - added Fertilizer & Pesticide
   *******************************************************************************/
 
 namespace AgGateway.ADAPT.ApplicationDataModel.Products


### PR DESCRIPTION
Signed-off-by: Jason Roesbeke jason.roesbeke@cnhind.com

See issue: [163](https://github.com/ADAPT/ADAPT/issues/163) Updated product CategoryEnum values for non-manure fertilizers and non-Insecticide pesticides. 
See issue: [146](https://github.com/ADAPT/ADAPT/issues/146) Added a list of TimeScopes to be able to add creation time and any possible modification time afterwards in a Prescription. 
See issue: [146](https://github.com/ADAPT/ADAPT/issues/146) Added PersonRoles to Precription to be able to record who created it.
See issue: [146](https://github.com/ADAPT/ADAPT/issues/146) **Changed the class name of RxRates to RxCellLookup (in RasterGridPrescription)**. See VectorPrescription: RxShapeLookup has similar working. 
See issue: [146](https://github.com/ADAPT/ADAPT/issues/145) Added Satellite Based Augmentation System & Precise Point Positioning to the GpsSourceEnum to make it more generic.
See issue: [144](https://github.com/ADAPT/ADAPT/issues/144) Added Description property to OperationSummary & OperationData because there is no way to identify which kind it is. E.g. summary of vehicle performance, of harvesting, of each applied product. **Must eventually be changed to an EnumeratedValue** to provide more detailed, machine-readable semantics that can help process OperationData and OperationSummary better.
See issue: [138](https://github.com/ADAPT/ADAPT/issues/138) Added Irrigation to the OperationTypeEnum.