### PR TITLE
Added IEnumerable of Loads to Documents - Issue #129

### DIFF
--- a/source/ADAPT/ADM/Documents.cs
+++ b/source/ADAPT/ADM/Documents.cs
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
  * Copyright (C) 2015 AgGateway and ADAPT Contributors
  * Copyright (C) 2015 Deere and Company
  * All rights reserved. This program and the accompanying materials
@@ -12,12 +12,14 @@
  *    Tarak Reddy - Mowed LoggedData and OperationData from LoggedDataCatalog
  *    Tarak Reddy - Moved GuidanceAllocations from Catalog
  *    Kathleen Oneal - added Summaries and LoggedDataCatalog
+ *    Tim Shearouse - Added Loads
  *******************************************************************************/
 
 using System.Collections.Generic;
 using AgGateway.ADAPT.ApplicationDataModel.Documents;
 using AgGateway.ADAPT.ApplicationDataModel.Guidance;
 using AgGateway.ADAPT.ApplicationDataModel.Equipment;
+using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
 
 namespace AgGateway.ADAPT.ApplicationDataModel.ADM
 {
@@ -35,6 +37,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.ADM
             Summaries = new List<Summary>();
             WorkRecords = new List<WorkRecord>();
             DeviceElementUses = new List<DeviceElementUse>();
+            Loads = new List<Load>();
         }
 
         public IEnumerable<WorkItem> WorkItems { get; set; }
@@ -58,5 +61,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.ADM
         public int LoggedDataCatalog { get; set; }
 
         public IEnumerable<DeviceElementUse> DeviceElementUses { get; set; }
+
+        public IEnumerable<Load> Loads { get; set; }
     }
 }

--- a/source/ADAPT/LoggedData/Load.cs
+++ b/source/ADAPT/LoggedData/Load.cs
@@ -4,7 +4,7 @@
   * All rights reserved. This program and the accompanying materials
   * are made available under the terms of the Eclipse Public License v1.0
   * which accompanies this distribution, and is available at
-  * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+  * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html>
   *
   * Contributors:
   *    Tarak Reddy, Tim Shearouse - initial API and implementation
@@ -14,6 +14,7 @@
 
 
 using System.Collections.Generic;
+using AgGateway.ADAPT.ApplicationDataModel.Common;
 using AgGateway.ADAPT.ApplicationDataModel.Representations;
 
 namespace AgGateway.ADAPT.ApplicationDataModel.LoggedData
@@ -24,9 +25,10 @@ namespace AgGateway.ADAPT.ApplicationDataModel.LoggedData
         {
             TimeScopeIds = new List<int>();
             DestinationIds = new List<int>();
+            Id = CompoundIdentifierFactory.Instance.Create();
         }
 
-        public int Id { get; set; }
+        public CompoundIdentifier Id { get; set; }
 
         public string Description { get; set; }
 

--- a/source/ADAPT/LoggedData/Load.cs
+++ b/source/ADAPT/LoggedData/Load.cs
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
   * Copyright (C) 2015 AgGateway and ADAPT Contributors
   * Copyright (C) 2015 Deere and Company
   * All rights reserved. This program and the accompanying materials
@@ -22,7 +22,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.LoggedData
     {
         public Load()
         {
-            TimeScopeIds =new List<int>();
+            TimeScopeIds = new List<int>();
             DestinationIds = new List<int>();
         }
 


### PR DESCRIPTION
Signed-off-by: Tim Shearouse <ShearouseTimothyW@JohnDeere.com>

Per issue #129 
Additional discussion may be needed:
 - Should the "Load" object be moved to the Documents namespace instead of the LoggedData namespace? I vote no because Loads are referenced by LoggedData, but I don't have a strong opinion.
 - Is the integer "Load.Id" property correct, or should it be a CompoundIdentifier? Changing this would be a breaking change, but if anyone uses non-integer id's for loads it would be a necessary change.