### PR TITLE
GeopoliticalContext-related additions to pave way for PAIL Observations

### DIFF
--- a/source/ADAPT/Common/GPCLevelEnum.cs
+++ b/source/ADAPT/Common/GPCLevelEnum.cs
@@ -1,0 +1,27 @@
+/*******************************************************************************
+  * Copyright (C) 2018 AgGateway and ADAPT Contributors
+  * All rights reserved. This program and the accompanying materials
+  * are made available under the terms of the Eclipse Public License v1.0
+  * which accompanies this distribution, and is available at
+  * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+  *
+  * Contributors:
+  *    R. Andres Ferreyra - initial port from PAIL Obs schema
+
+  *******************************************************************************/  
+
+namespace AgGateway.ADAPT.ApplicationDataModel.Common
+{
+    /// <summary>
+    /// Describes the hierarchical level of the geopolitical context:
+    /// - Country
+    /// - Administrative level 1 (e.g., US States, Canadian provinces, Russian oblasts) 
+    /// - Administrative level 2 (e.g., US counties)
+    /// </summary>
+    public enum GPCLevelEnum
+    {
+        Country,
+        ADM1,
+        ADM2
+    }
+}

--- a/source/ADAPT/Common/GPCSourceVocEnum.cs
+++ b/source/ADAPT/Common/GPCSourceVocEnum.cs
@@ -17,8 +17,8 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Common
     /// </summary>
     public enum GPCSourceVocEnum
     {
-        ISO3166-1A3,
-        ISO3166-2,
+        ISO3166_1A3,
+        ISO3166_2,
         GeoNames,
         FAOGPO
     }

--- a/source/ADAPT/Common/GPCSourceVocEnum.cs
+++ b/source/ADAPT/Common/GPCSourceVocEnum.cs
@@ -1,0 +1,25 @@
+/*******************************************************************************
+  * Copyright (C) 2018 AgGateway and ADAPT Contributors
+  * All rights reserved. This program and the accompanying materials
+  * are made available under the terms of the Eclipse Public License v1.0
+  * which accompanies this distribution, and is available at
+  * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+  *
+  * Contributors:
+  *    R. Andres Ferreyra - initial port from PAIL Obs schema
+
+  *******************************************************************************/  
+
+namespace AgGateway.ADAPT.ApplicationDataModel.Common
+{
+    /// <summary>
+    /// Describes the organization or standard that minted the geopolitical context code.
+    /// </summary>
+    public enum GPCSourceVocEnum
+    {
+        ISO3166-1A3,
+        ISO3166-2,
+        GeoNames,
+        FAOGPO
+    }
+}

--- a/source/ADAPT/Common/GeoPoliticalContext.cs
+++ b/source/ADAPT/Common/GeoPoliticalContext.cs
@@ -12,6 +12,7 @@
   *    Joseph Ross - Adding intializer for id
   *    R. Andres Ferreyra - Added GPCLevel, GPCVocSource, Lexicalizations 
   *******************************************************************************/
+using System.Collections.Generic;
 
 namespace AgGateway.ADAPT.ApplicationDataModel.Common
 {

--- a/source/ADAPT/Common/GeoPoliticalContext.cs
+++ b/source/ADAPT/Common/GeoPoliticalContext.cs
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
   * Copyright (C) 2015-16 AgGateway and ADAPT Contributors
   * Copyright (C) 2016 Ag Connections
   * Copyright (C) 2015 Deere and Company
@@ -10,13 +10,14 @@
   * Contributors:
   *    Stuart Rhea - initial API and implementation
   *    Joseph Ross - Adding intializer for id
+  *    R. Andres Ferreyra - Added GPCLevel, GPCVocSource, Lexicalizations 
   *******************************************************************************/
 
 namespace AgGateway.ADAPT.ApplicationDataModel.Common
 {
     /// <summary>
-    /// We will use the FAO's Geopolitical Ontology (http://www.fao.org/countryprofiles/geoinfo/en/) as our starting point; 
-    /// though its granularity is probably insufficient for our ultimate goals. For example,
+    /// If the GPCVocSource is not present, we assume the FAO's Geopolitical Ontology (http://www.fao.org/countryprofiles/geoinfo/en/).
+    /// For example,
     /// it contains economic regions(EU) and organizations(FAO), but not the individual US states. We'll add entries as 
     /// needed and objects will be used by reference.
     /// </summary>
@@ -27,6 +28,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Common
         public GeoPoliticalContext()
         {
             Id = CompoundIdentifierFactory.Instance.Create();
+            Lexicalizations = new List<Lexicalization>();
         }
 
         /// <summary>
@@ -46,5 +48,24 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Common
         /// <value>
         /// This is a "friendly name" that should make selection from a pick list easier. This value is required.</value>
         public string Description { get; set; }
+ 
+ 
+        /// <summary>
+        /// GPCLevel property. </summary>
+        /// <value>
+        /// Describes whether the GPC is a country, level-1 administrative unit (e.g., state or province), or a level-2 unit (e.g., county).</value>
+        public GPCLevelEnum? GPCLevel { get; set; }
+
+        /// <summary>
+        /// GPCVocSource property. </summary>
+        /// <value>
+        /// Describes the organization that minted the GPC code: an ISO standard, GeoNames, FAO Geopolitical Ontology.</value>
+        public GPCSourceVocEnum? GPCVocSource { get; set; }
+
+        /// <summary>
+        /// Lexicalizations property. </summary>
+        /// <value>
+        /// Provides strings human-readable labels for the geopolitical context, in specific languages.</value>
+        public List<Lexicalization> Lexicalizations { get; set; }
     }
 }


### PR DESCRIPTION
Preparing to add PAIL Observations objects, which use a more complete GeopoliticalContext class than the skeleton currently implemented in ADAPT. Includes three files:
- An enumeration describing whether the geopolitical context in question is a country, ADM1 (state/province/oblast, etc.), or ADM2 (county)
- An enumeration describing the standard or organization that minted the GPC code
- An updated version of the GeoPoliticalContext class, including attributes for the above, as well as a list of lexicalizations.