### PR TITLE
PAIL RadialPrescription and supporting classes

### DIFF
--- a/source/ADAPT/Prescriptions/RadialExtent.cs
+++ b/source/ADAPT/Prescriptions/RadialExtent.cs
@@ -1,5 +1,5 @@
 /*******************************************************************************
-  * Copyright (C) 2015 AgGateway and ADAPT Contributors
+  * Copyright (C) 2015, 2018 AgGateway and ADAPT Contributors
   * Copyright (C) 2015 Deere and Company
   * All rights reserved. This program and the accompanying materials
   * are made available under the terms of the Eclipse Public License v1.0

--- a/source/ADAPT/Prescriptions/RadialExtent.cs
+++ b/source/ADAPT/Prescriptions/RadialExtent.cs
@@ -1,0 +1,39 @@
+/*******************************************************************************
+  * Copyright (C) 2015 AgGateway and ADAPT Contributors
+  * Copyright (C) 2015 Deere and Company
+  * All rights reserved. This program and the accompanying materials
+  * are made available under the terms of the Eclipse Public License v1.0
+  * which accompanies this distribution, and is available at
+  * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+  *
+  * Contributors:
+  *    
+  *    
+  *******************************************************************************/
+using System.Collections.Generic;
+using AgGateway.ADAPT.ApplicationDataModel.Representations;
+using AgGateway.ADAPT.ApplicationDataModel.Shapes;
+
+namespace AgGateway.ADAPT.ApplicationDataModel.Prescriptions
+{
+    public class RadialExtent
+    {
+        public RadialExtent()
+        {
+            
+        }
+        
+        public NumericRepresentationValue StartAngle { get; set; }
+
+        public NumericRepresentationValue EndAngle { get; set; }
+
+        public int? SectionId { get; set; }
+
+        public NumericRepresentationValue InnerRadius { get; set; }
+
+        public NumericRepresentationValue OuterRadius { get; set; }
+
+        public Point RotCtr { get; set; }
+
+    }
+}

--- a/source/ADAPT/Prescriptions/RadialLookupCollection.cs
+++ b/source/ADAPT/Prescriptions/RadialLookupCollection.cs
@@ -18,7 +18,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Prescriptions
 {
     public class RadialLookupCollection
     {
-        public RadialPrescription()
+        public RadialLookupCollection()
         {
             RadialLookups = new List<RxRadialLookup>();
             ShapeLookups = new List<RxShapeLookup>();

--- a/source/ADAPT/Prescriptions/RadialLookupCollection.cs
+++ b/source/ADAPT/Prescriptions/RadialLookupCollection.cs
@@ -1,5 +1,5 @@
 /*******************************************************************************
-  * Copyright (C) 2015 AgGateway and ADAPT Contributors
+  * Copyright (C) 2015, 2018 AgGateway and ADAPT Contributors
   * Copyright (C) 2015 Deere and Company
   * All rights reserved. This program and the accompanying materials
   * are made available under the terms of the Eclipse Public License v1.0

--- a/source/ADAPT/Prescriptions/RadialLookupCollection.cs
+++ b/source/ADAPT/Prescriptions/RadialLookupCollection.cs
@@ -1,0 +1,36 @@
+/*******************************************************************************
+  * Copyright (C) 2015 AgGateway and ADAPT Contributors
+  * Copyright (C) 2015 Deere and Company
+  * All rights reserved. This program and the accompanying materials
+  * are made available under the terms of the Eclipse Public License v1.0
+  * which accompanies this distribution, and is available at
+  * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+  *
+  * Contributors:
+  *    
+  *    
+  *******************************************************************************/
+using System.Collections.Generic;
+using AgGateway.ADAPT.ApplicationDataModel.Representations;
+using AgGateway.ADAPT.ApplicationDataModel.Shapes;
+
+namespace AgGateway.ADAPT.ApplicationDataModel.Prescriptions
+{
+    public class RadialLookupCollection
+    {
+        public RadialPrescription()
+        {
+            RadialLookups = new List<RxRadialLookup>();
+            ShapeLookups = new List<RxShapeLookup>();
+        }
+        public List<RxRadialLookup> RadialLookups { get; set; }
+
+        public NumericRepresentationValue StartAngle { get; set; }
+
+        public NumericRepresentationValue EndAngle { get; set; }
+
+        public Point RotCtr { get; set; }
+
+        public List<RxShapeLookup> ShapeLookups { get; set; }
+    }
+}

--- a/source/ADAPT/Prescriptions/RadialPrescription.cs
+++ b/source/ADAPT/Prescriptions/RadialPrescription.cs
@@ -1,0 +1,26 @@
+/*******************************************************************************
+  * Copyright (C) 2015 AgGateway and ADAPT Contributors
+  * Copyright (C) 2015 Deere and Company
+  * All rights reserved. This program and the accompanying materials
+  * are made available under the terms of the Eclipse Public License v1.0
+  * which accompanies this distribution, and is available at
+  * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+  *
+  * Contributors:
+  *    
+  *******************************************************************************/
+
+using System.Collections.Generic;
+
+namespace AgGateway.ADAPT.ApplicationDataModel.Prescriptions
+{
+    public class RadialPrescription : SpatialPrescription
+    {
+        public RadialPrescription()
+        {
+            RadialLookupCollections = new List<RadialLookupCollection>();
+        }
+
+        public List<RadialLookupCollection> RadialLookupCollections { get; set; }
+    }
+}

--- a/source/ADAPT/Prescriptions/RadialPrescription.cs
+++ b/source/ADAPT/Prescriptions/RadialPrescription.cs
@@ -1,5 +1,5 @@
 /*******************************************************************************
-  * Copyright (C) 2015 AgGateway and ADAPT Contributors
+  * Copyright (C) 2015, 2018 AgGateway and ADAPT Contributors
   * Copyright (C) 2015 Deere and Company
   * All rights reserved. This program and the accompanying materials
   * are made available under the terms of the Eclipse Public License v1.0

--- a/source/ADAPT/Prescriptions/RxRadialLookup.cs
+++ b/source/ADAPT/Prescriptions/RxRadialLookup.cs
@@ -1,0 +1,28 @@
+/*******************************************************************************
+  * Copyright (C) 2015 AgGateway and ADAPT Contributors
+  * Copyright (C) 2015 Deere and Company
+  * All rights reserved. This program and the accompanying materials
+  * are made available under the terms of the Eclipse Public License v1.0
+  * which accompanies this distribution, and is available at
+  * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+  *
+  * Contributors:
+  *    
+  *    
+  *******************************************************************************/
+
+using System.Collections.Generic;
+
+namespace AgGateway.ADAPT.ApplicationDataModel.Prescriptions
+{
+    public class RxRadialLookup
+    {
+        public RxRadialLookup()
+        {
+            RxRates = new List<RxRate>();            
+        }
+        public RadialExtent Extent { get; set; }
+
+        public List<RxRate> RxRates { get; set; }
+    }
+}

--- a/source/ADAPT/Prescriptions/RxRadialLookup.cs
+++ b/source/ADAPT/Prescriptions/RxRadialLookup.cs
@@ -1,5 +1,5 @@
 /*******************************************************************************
-  * Copyright (C) 2015 AgGateway and ADAPT Contributors
+  * Copyright (C) 2015, 2018 AgGateway and ADAPT Contributors
   * Copyright (C) 2015 Deere and Company
   * All rights reserved. This program and the accompanying materials
   * are made available under the terms of the Eclipse Public License v1.0


### PR DESCRIPTION
Introduces RadialPrescription, a child class of SpatialPrescription. It is meant to efficiently handle the radial shorthand used in the PAIL schema. There are four classes:
- RadialPrescription: A child class of SpatialPrescription. Basically a list of RadialLookupCollections.
- RadialLookupCollection: Represents a "pie slice" in a center pivot or similar system. Contains a list of RxRadialLookups analogous to the content of a VectorPrescription, but which describe radial pie slice segments instead of multipolygons. Also contains a list of RxShapeLookups, to represent swing-arm corners, the footprints of which do not conform to a radial geometry.
- RxRadialLookup: Analogous to RxShapeLookup, but using a radial geometry.
- RadialExtent: Description of a pie slice segment.
Note that collections and extents both include optional centers of rotation. This enables representing primaries and wraps/benders.