### PR TITLE
SetupDataPedigree enumeration

### DIFF
--- a/source/ADAPT/Common/SetupDataPedigreeEnum.cs
+++ b/source/ADAPT/Common/SetupDataPedigreeEnum.cs
@@ -5,16 +5,31 @@
   * which accompanies this distribution, and is available at
   * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
   *
-  * Contributors: Aaron Berger: transcribed from PAIL Part 1 schema.
+  * Contributors: Aaron Berger: transcribed from PAIL Part 1 schema. Andres Ferreyra: Added documentation.
   *    
   *******************************************************************************/
 
 namespace AgGateway.ADAPT.ApplicationDataModel.Common
 {
+     /// <summary>
+     /// Telemetry systems are plagued with data-orphaning problems when stored system setup/configuration (meta)data get out of sync 
+     /// with the transactional data. This class provides a vocabulary for describing the telemetry system's ability to keep
+     /// data and metadata in sync. Its values can advise a user when formulating a data-polling strategy; e.g., if a system is keeping
+     /// only the latest version of its setup & configuration data, the user will be well-served by downloading data frequently.
+     /// </summary>
     public enum SetupDataPedigreeEnum
     {
+        /// <summary>
+        /// The system is only keeping the latest copy of setup/configuration data. 
+        /// </summary>
         LatestOnly,
+        /// <summary>
+        /// The system is keeping multiple versions of setup/configuration data, and keeping them time-binned. 
+        /// </summary>
         MatchedByTimeInterval,
+        /// <summary>
+        /// The strategy used by the system for tracking changes in system configuration is unknown. 
+        /// </summary>
         Unknown
     }
 }

--- a/source/ADAPT/Common/SetupDataPedigreeEnum.cs
+++ b/source/ADAPT/Common/SetupDataPedigreeEnum.cs
@@ -1,0 +1,20 @@
+/*******************************************************************************
+  * Copyright (C) 2018 AgGateway and ADAPT Contributors
+  * All rights reserved. This program and the accompanying materials
+  * are made available under the terms of the Eclipse Public License v1.0
+  * which accompanies this distribution, and is available at
+  * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+  *
+  * Contributors: Aaron Berger: transcribed from PAIL Part 1 schema.
+  *    
+  *******************************************************************************/
+
+namespace AgGateway.ADAPT.ApplicationDataModel.Common
+{
+    public enum SetupDataPedigreeEnum
+    {
+        LatestOnly,
+        MatchedByTimeInterval,
+        Unknown
+    }
+}

--- a/source/ADAPT/Equipment/DeviceSeries.cs
+++ b/source/ADAPT/Equipment/DeviceSeries.cs
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (C) 2018 AgGateway and ADAPT Contributors
+ * Copyright (C) 2018 Ag Connections LLC
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+ *
+ * Contributors:
+ *    R. Andres FerreyraJustin Sliekers - initial port from ADAPT data model
+ *******************************************************************************/
+
+using AgGateway.ADAPT.ApplicationDataModel.Common;
+using System.Collections.Generic;
+
+namespace AgGateway.ADAPT.ApplicationDataModel.Equipment
+{
+    public class DeviceSeries
+    {
+        public DeviceSeries()
+        {
+            Id = CompoundIdentifierFactory.Instance.Create();
+            ContextItems = new List<ContextItem>();
+        }
+
+        public CompoundIdentifier Id { get; private set; }
+
+        public string Description { get; set; }
+
+        public int BrandId { get; set; }
+
+        public List<ContextItem> ContextItems { get; set; }
+    }
+}


### PR DESCRIPTION
Used to describe the strategy of a dataset provider regarding the persistence of setup/configuration data. May be very important for interpreting datasets, and for formulating a strategy for how often to pull data from a provider.