### PR TITLE
UnitOfMeasureAuthorityEnum.cs

### DIFF
--- a/source/ADAPT/Common/UnitOfMeasureAuthorityEnum.cs
+++ b/source/ADAPT/Common/UnitOfMeasureAuthorityEnum.cs
@@ -1,0 +1,21 @@
+/*******************************************************************************
+  * Copyright (C) 2018 AgGateway and ADAPT Contributors
+  * All rights reserved. This program and the accompanying materials
+  * are made available under the terms of the Eclipse Public License v1.0
+  * which accompanies this distribution, and is available at
+  * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+  *
+  * Contributors: Aaron Berger: transcribed from PAIL Part 1 schema.  
+  *    
+  *******************************************************************************/
+
+namespace AgGateway.ADAPT.ApplicationDataModel.Common
+{
+    public enum UnitOfMeasureAuthorityEnum
+    {
+        UNRec20,
+        QUDT,
+        UCUM,
+        ADAPT
+    }
+}

--- a/source/ADAPT/Equipment/DeviceSeries.cs
+++ b/source/ADAPT/Equipment/DeviceSeries.cs
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (C) 2018 AgGateway and ADAPT Contributors
+ * Copyright (C) 2018 Ag Connections LLC
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+ *
+ * Contributors:
+ *    R. Andres FerreyraJustin Sliekers - initial port from ADAPT data model
+ *******************************************************************************/
+
+using AgGateway.ADAPT.ApplicationDataModel.Common;
+using System.Collections.Generic;
+
+namespace AgGateway.ADAPT.ApplicationDataModel.Equipment
+{
+    public class DeviceSeries
+    {
+        public DeviceSeries()
+        {
+            Id = CompoundIdentifierFactory.Instance.Create();
+            ContextItems = new List<ContextItem>();
+        }
+
+        public CompoundIdentifier Id { get; private set; }
+
+        public string Description { get; set; }
+
+        public int BrandId { get; set; }
+
+        public List<ContextItem> ContextItems { get; set; }
+    }
+}


### PR DESCRIPTION
ADAPT (currently) uses only one set of symbols for unit of measure (the one provided by Deere); PAIL can accommodate several.
Although the intent of the PAIL Team is for the PAIL plug-in to convert incoming values to ADAPT-specific RepresentationValues, it is useful to be able to keep track of what set of units was used in an incoming dataset (as well as capture preferences for PAIL-plugin exports).
This enumeration provides the full set of PAIL UoM authority codes (including ADAPT).