### PR TITLE
EndgunSetup

### DIFF
--- a/source/ADAPT/Equipment/DeviceSeries.cs
+++ b/source/ADAPT/Equipment/DeviceSeries.cs
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (C) 2018 AgGateway and ADAPT Contributors
+ * Copyright (C) 2018 Ag Connections LLC
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+ *
+ * Contributors:
+ *    R. Andres FerreyraJustin Sliekers - initial port from ADAPT data model
+ *******************************************************************************/
+
+using AgGateway.ADAPT.ApplicationDataModel.Common;
+using System.Collections.Generic;
+
+namespace AgGateway.ADAPT.ApplicationDataModel.Equipment
+{
+    public class DeviceSeries
+    {
+        public DeviceSeries()
+        {
+            Id = CompoundIdentifierFactory.Instance.Create();
+            ContextItems = new List<ContextItem>();
+        }
+
+        public CompoundIdentifier Id { get; private set; }
+
+        public string Description { get; set; }
+
+        public int BrandId { get; set; }
+
+        public List<ContextItem> ContextItems { get; set; }
+    }
+}

--- a/source/ADAPT/Equipment/EndgunSetup.cs
+++ b/source/ADAPT/Equipment/EndgunSetup.cs
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (C) 2018 AgGateway and ADAPT Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+ *
+ * Contributors: Aaron Berger: Translate from PAIL Part 3 Schema
+ *    
+ *******************************************************************************/
+
+
+namespace AgGateway.ADAPT.ApplicationDataModel.Equipment
+{
+    class EndgunSetup
+    {
+        public int ManufacturerId { get; set; }
+        public int ModelId { get; set; }
+        public EndgunTableEntry NominalValues { get; set; }
+        public EndgunTable TabularValues { get; set; }
+    }
+}


### PR DESCRIPTION
Contains information needed to describe how an endgun is set up. Used by value within IrrSystemConfiguration (as opposed to, say, having an EndgunConfiguration specialization of DeviceElementConfiguration) because PAIL treats endguns as a special kind of IrrSection, as opposed to a standalone implement / deviceelement.