### PR TITLE
EndgunTableEntry, EndgunTable, EndgunSetup

### DIFF
--- a/source/ADAPT/Equipment/DeviceSeries.cs
+++ b/source/ADAPT/Equipment/DeviceSeries.cs
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (C) 2018 AgGateway and ADAPT Contributors
+ * Copyright (C) 2018 Ag Connections LLC
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+ *
+ * Contributors:
+ *    R. Andres FerreyraJustin Sliekers - initial port from ADAPT data model
+ *******************************************************************************/
+
+using AgGateway.ADAPT.ApplicationDataModel.Common;
+using System.Collections.Generic;
+
+namespace AgGateway.ADAPT.ApplicationDataModel.Equipment
+{
+    public class DeviceSeries
+    {
+        public DeviceSeries()
+        {
+            Id = CompoundIdentifierFactory.Instance.Create();
+            ContextItems = new List<ContextItem>();
+        }
+
+        public CompoundIdentifier Id { get; private set; }
+
+        public string Description { get; set; }
+
+        public int BrandId { get; set; }
+
+        public List<ContextItem> ContextItems { get; set; }
+    }
+}

--- a/source/ADAPT/Equipment/EndgunSetup.cs
+++ b/source/ADAPT/Equipment/EndgunSetup.cs
@@ -12,7 +12,7 @@
 
 namespace AgGateway.ADAPT.ApplicationDataModel.Equipment
 {
-    class EndgunSetup
+    public class EndgunSetup
     {
         public int ManufacturerId { get; set; }
         public int ModelId { get; set; }

--- a/source/ADAPT/Equipment/EndgunSetup.cs
+++ b/source/ADAPT/Equipment/EndgunSetup.cs
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (C) 2018 AgGateway and ADAPT Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+ *
+ * Contributors: Aaron Berger: Translate from PAIL Part 3 Schema
+ *    
+ *******************************************************************************/
+
+
+namespace AgGateway.ADAPT.ApplicationDataModel.Equipment
+{
+    class EndgunSetup
+    {
+        public int ManufacturerId { get; set; }
+        public int ModelId { get; set; }
+        public EndgunTableEntry NominalValues { get; set; }
+        public EndgunTable TabularValues { get; set; }
+    }
+}

--- a/source/ADAPT/Equipment/EndgunTable.cs
+++ b/source/ADAPT/Equipment/EndgunTable.cs
@@ -13,7 +13,7 @@ using System.Collections.Generic;
 namespace AgGateway.ADAPT.ApplicationDataModel.Equipment
 
 {
-    class EndgunTable
+    public class EndgunTable
     {
         public EndgunTable()
         {

--- a/source/ADAPT/Equipment/EndgunTable.cs
+++ b/source/ADAPT/Equipment/EndgunTable.cs
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (C) 2016 AgGateway and ADAPT Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+ *
+ * Contributors: Aaron Berger: Transcribed from PAIL
+ *    
+ *******************************************************************************/
+
+using System.Collections.Generic;
+namespace AgGateway.ADAPT.ApplicationDataModel.Equipment
+
+{
+    class EndgunTable
+    {
+        public EndgunTable()
+        {
+            TableEntries = new List<EndgunTableEntry>();
+        }
+        public List<EndgunTableEntry> TableEntries { get; set; }
+    }
+}

--- a/source/ADAPT/Equipment/EndgunTableEntry.cs
+++ b/source/ADAPT/Equipment/EndgunTableEntry.cs
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (C) 2018 AgGateway and ADAPT Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+ *
+ * Contributors: Aaron Berger, Andres Ferreyra: Translated from PAIL
+ *    
+ *******************************************************************************/
+
+using AgGateway.ADAPT.ApplicationDataModel.Representations;
+
+namespace AgGateway.ADAPT.ApplicationDataModel.Equipment
+{
+    class EndgunTableEntry
+    {
+        public NumericRepresentationValue Pressure { get; set; }
+        public NumericRepresentationValue FlowValue { get; set; }
+        public NumericRepresentationValue ThrowValue { get; set; }
+    }
+}

--- a/source/ADAPT/Equipment/EndgunTableEntry.cs
+++ b/source/ADAPT/Equipment/EndgunTableEntry.cs
@@ -13,7 +13,7 @@ using AgGateway.ADAPT.ApplicationDataModel.Representations;
 
 namespace AgGateway.ADAPT.ApplicationDataModel.Equipment
 {
-    class EndgunTableEntry
+    public class EndgunTableEntry
     {
         public NumericRepresentationValue Pressure { get; set; }
         public NumericRepresentationValue FlowValue { get; set; }


### PR DESCRIPTION
The EndgunTableEntry and EndgunTable classes enable the description of two behaviors of an endgun: its throw vs pressure, and flow vs pressure functions. Used in EndgunSetup, which describes the particular endgun being used. It's used by value in IrrSystemConfiguration (as opposed to being a descendant of DeviceElementConfig) because PAIL considers endguns a special kind of section, and endgun setup data is not always available. 