### PR TITLE
Issues 133 & 137 - Error Reporting & Handling contemporaneous OperationData objects; also deafult DDI mapping in RepresentationSystem

### DIFF
--- a/source/ADAPT/ADM/IPlugin.cs
+++ b/source/ADAPT/ADM/IPlugin.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace AgGateway.ADAPT.ApplicationDataModel.ADM
 {
@@ -13,6 +13,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.ADM
         IList<ApplicationDataModel> Import(string dataPath, Properties properties = null);
         void Export(ApplicationDataModel dataModel, string exportPath, Properties properties = null);
         Properties GetProperties(string dataPath);
+        IList<IError> Errors { get; }
     }
 
     public interface IError

--- a/source/ADAPT/LoggedData/OperationData.cs
+++ b/source/ADAPT/LoggedData/OperationData.cs
@@ -11,7 +11,9 @@
   *    Kathleen Oneal - removed implementConfigId and machineConfigId, added EquipmentConfigId
   *    Justin Sliekers - implement device element changes
   *    Joseph Ross - Added EquipmentConfigurationGroup
-  *	   Jason Roesbeke - added Description    
+  *	   Jason Roesbeke - added Description
+  *	   Kelly Nelson -  Changed ProductId to allow for multiples
+  *	   Kelly Nelson -  Added CoinicidentOperationDataIDs
   *******************************************************************************/
 
 using System;
@@ -37,7 +39,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.LoggedData
 
         public int? PrescriptionId { get; set; }
 
-        public List<int> ProductId { get; set; }
+        public List<int> ProductIds { get; set; }
 
         public int? VarietyLocatorId { get; set; }
 
@@ -54,6 +56,8 @@ namespace AgGateway.ADAPT.ApplicationDataModel.LoggedData
         public Func<int, IEnumerable<DeviceElementUse>> GetDeviceElementUses { get; set; }
 
         public string Description { get; set; }
+
+        public List<int> CoincidentOperationDataIds { get; set; }
 
     }
 }

--- a/source/Representation/Resources/RepresentationSystem.xsd
+++ b/source/Representation/Resources/RepresentationSystem.xsd
@@ -100,6 +100,7 @@ If not present the unit of measure lable will be used.</xs:documentation>
 												<xs:attribute name="unitOfMeasure" type="unit:unitOfMeasureDomainID" use="required"/>
 												<xs:attribute name="resolution" type="xs:double" default="1"/>
 												<xs:attribute name="offset" type="xs:double" default="0"/>
+                        <xs:attribute name="isDefaultRepresentationForDDI" type="xs:string" use="optional"/>
 											</xs:complexType>
 										</xs:element>
 									</xs:sequence>
@@ -177,6 +178,7 @@ If not present the unit of measure lable will be used.</xs:documentation>
 										<xs:element name="RelatedDDI" minOccurs="0" maxOccurs="unbounded">
 											<xs:complexType>
 												<xs:attribute name="ddi" type="xs:int" use="required"/>
+                        <xs:attribute name="isDefaultRepresentationForDDI" type="xs:string" use="optional"/>
 											</xs:complexType>
 										</xs:element>
 									</xs:sequence>

--- a/source/TestPlugin/TestPlugin.cs
+++ b/source/TestPlugin/TestPlugin.cs
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
   * Copyright (C) 2015 AgGateway and ADAPT Contributors
   * Copyright (C) 2015 Deere and Company
   * All rights reserved. This program and the accompanying materials
@@ -8,6 +8,7 @@
   *
   * Contributors:
   *    Tarak Reddy, Tim Shearouse - initial API and implementation
+  *    Kelly Nelson - Added Errors collection
   *******************************************************************************/
 
 using System.Collections.Generic;
@@ -54,5 +55,8 @@ namespace AgGateway.ADAPT.TestPlugin
       {
          return new Properties();
       }
-   }
+
+      public IList<IError> Errors { get { return new List<IError>(); } } 
+
+    }
 }


### PR DESCRIPTION
I implemented this approach for contemporaneous OperationData objects vs. the WorkItem workaround proposed in #137.   9/10 of the time, there is no WorkItem whereas a single pass application of seed + chemical or fertilizer is quite common.    Introducing many dummy WorkItems would further confuse the model as WorkItem is a constituent of a WorkOrder vs. WorkRecord and LoggedData which are in this case the relevant document constructs.