### PR TITLE
Adding CornerArmTypeEnum

### DIFF
--- a/source/ADAPT/Equipment/CornerArmTypeEnum.cs
+++ b/source/ADAPT/Equipment/CornerArmTypeEnum.cs
@@ -1,0 +1,24 @@
+/*******************************************************************************
+  * Copyright (C) 2015 AgGateway and ADAPT Contributors
+  * Copyright (C) 2015 Deere and Company
+  * All rights reserved. This program and the accompanying materials
+  * are made available under the terms of the Eclipse Public License v1.0
+  * which accompanies this distribution, and is available at
+  * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+  *
+  * Contributors: Aaron Berger, transcribe from PAIL; R. Andres Ferreyra, documentation.
+  *    
+  *    
+  *******************************************************************************/
+
+namespace AgGateway.ADAPT.ApplicationDataModel.Equipment
+{
+    /// <summary>
+    /// This vocabulary specifies whether a corner arm on a pivot is leading or trailing the primary WHEN MOVING CLOCKWISE.
+    /// </summary>
+    public enum CornerArmTypeEnum
+    {
+        Leading,
+        Trailing
+    }
+}


### PR DESCRIPTION
Provides a vocabulary for specifying the type of a center pivot corner arm.