### PR TITLE
Fixing typo & bug in Load

### DIFF
--- a/source/ADAPT/LoggedData/Load.cs
+++ b/source/ADAPT/LoggedData/Load.cs
@@ -1,5 +1,5 @@
 /*******************************************************************************
-  * Copyright (C) 2015 AgGateway and ADAPT Contributors
+  * Copyright (C) 2015, 2018 AgGateway and ADAPT Contributors
   * Copyright (C) 2015 Deere and Company
   * All rights reserved. This program and the accompanying materials
   * are made available under the terms of the Eclipse Public License v1.0
@@ -10,6 +10,8 @@
   *    Tarak Reddy, Tim Shearouse - initial API and implementation
   *    Justin Sliekers - udpating DefinedRepresentation to EnumeratedRepresentation
   *    Justin Sliekers - udpating DestinationId to collection and changed loadtype from EnumeratedRepresentation to LoadTypeEnum
+  *    R. Andres Ferreyra - fixing typo: renaming LoadQuality to LoadQuantity. Adding QUALITY attributes (i.e, OMs) can wait to v2.1
+  *    R. ANdres Ferreyra - fixing bug: TimeScopes are used by value in ADAPT, not by reference. Changing accordingly. 
   *******************************************************************************/
 
 
@@ -23,7 +25,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.LoggedData
     {
         public Load()
         {
-            TimeScopeIds = new List<int>();
+            TimeScopes = new List<TimeScope>();
             DestinationIds = new List<int>();
             Id = CompoundIdentifierFactory.Instance.Create();
         }
@@ -32,13 +34,13 @@ namespace AgGateway.ADAPT.ApplicationDataModel.LoggedData
 
         public string Description { get; set; }
 
-        public List<int> TimeScopeIds { get; set; }
+        public List<TimeScope> TimeScopes { get; set; } // RAF 20181018: Changed this from a list of integer references.
 
         public string LoadNumber { get; set; }
 
         public LoadTypeEnum LoadType { get; set; }
 
-        public NumericRepresentationValue LoadQuality { get; set; }
+        public NumericRepresentationValue LoadQuantity { get; set; }
 
         public List<int> DestinationIds { get; set; }
     }


### PR DESCRIPTION
Fixing a typo: renaming LoadQuality attribute to LoadQuantity (an EnumeratedRepresentationValue)
Fixing a bug: The class used TimeScopes by REFERENCE. THat's not how TimeScopes are supposed to be used.