### PR TITLE
Adding PAIL-related items to DeviceElementTypeEnum

### DIFF
--- a/source/ADAPT/Equipment/DeviceElementTypeEnum.cs
+++ b/source/ADAPT/Equipment/DeviceElementTypeEnum.cs
@@ -1,5 +1,5 @@
 ﻿/*******************************************************************************
- * Copyright (C) 2016 AgGateway and ADAPT Contributors
+ * Copyright (C) 2016, 2018 AgGateway and ADAPT Contributors
  * Copyright (C) 2016 Deere and Company
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *    Justin Sliekers - implement device element changes, initial creation
+ *    R. Andres Ferreyra - Adding 3 Irrigation-related items: IrrSystem, IrrSection, and Endgun
  *******************************************************************************/
 
 namespace AgGateway.ADAPT.ApplicationDataModel.Equipment
@@ -20,6 +21,9 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Equipment
         Bin,
         Section,
         Unit,
-        Function
-    }
+        Function,
+        IrrSystem, // A mobile or fixed irrigation system such as a center pivot, linear, traveling gun, solid set, etc.
+        IrrSection, // A section of an IrrSystem. Different enough from a regular section to merit its own DeviceElementConfiguration
+        Endgun // A device attached to an irrigation system that projects water beyond it.
+     }
 }


### PR DESCRIPTION
Forgot to add IrrSystem, IrrSection, and Endgun. Needed to match the DeviceElement instance with its corresponding DeviceElementConfiguration-subclass instance.