### PR TITLE
Allowing for optional configuration of representation data locations

### DIFF
--- a/source/Representation/RepresentationSystem/RepresentationManager.cs
+++ b/source/Representation/RepresentationSystem/RepresentationManager.cs
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
   * Copyright (C) 2015 AgGateway and ADAPT Contributors
   * Copyright (C) 2015 Deere and Company
   * All rights reserved. This program and the accompanying materials
@@ -21,6 +21,21 @@ namespace AgGateway.ADAPT.Representation.RepresentationSystem
     {
         private static RepresentationManager _instance;
         private static readonly object BlueThreadLock = new Object();
+
+        private static string representationSystemDataLocation = null;
+
+        public static string RepresentationSystemDataLocation {
+            get {
+                if(representationSystemDataLocation == null) {
+                    var assemblyLocation = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
+                    var repSystemXml = Path.Combine(assemblyLocation, "Resources", "RepresentationSystem.xml");
+                    return repSystemXml;
+                } else {
+                    return representationSystemDataLocation;
+                }
+            }
+            set { representationSystemDataLocation = value; }
+        }
 
         public static RepresentationManager Instance
         {
@@ -56,10 +71,7 @@ namespace AgGateway.ADAPT.Representation.RepresentationSystem
         {
             var serializer = new XmlSerializer(typeof(Generated.RepresentationSystem));
 
-            var assemblyLocation = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
-            var repSystemXml = Path.Combine(assemblyLocation, "Resources", "RepresentationSystem.xml");
-
-            var xmlStringBytes = File.ReadAllBytes(repSystemXml);
+            var xmlStringBytes = File.ReadAllBytes(RepresentationSystemDataLocation);
             using (var stream = new MemoryStream(xmlStringBytes))
                 return (Generated.RepresentationSystem)serializer.Deserialize(stream);
         }

--- a/source/Representation/UnitSystem/InternalUnitSystemManager.cs
+++ b/source/Representation/UnitSystem/InternalUnitSystemManager.cs
@@ -93,10 +93,7 @@ namespace AgGateway.ADAPT.Representation.UnitSystem
         {
             var serializer = new XmlSerializer(typeof(Generated.UnitSystem));
 
-            var assemblyLocation = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
-            var unitSystemXml = Path.Combine(assemblyLocation, "Resources", "UnitSystem.xml");
-
-            var xmlStringBytes = File.ReadAllBytes(unitSystemXml);
+            var xmlStringBytes = File.ReadAllBytes(UnitSystemManager.UnitSystemDataLocation);
             using (var stream = new MemoryStream(xmlStringBytes))
                 return (Generated.UnitSystem)serializer.Deserialize(stream);
         }

--- a/source/Representation/UnitSystem/UnitSystemManager.cs
+++ b/source/Representation/UnitSystem/UnitSystemManager.cs
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
   * Copyright (C) 2015 AgGateway and ADAPT Contributors
   * Copyright (C) 2015 Deere and Company
   * All rights reserved. This program and the accompanying materials
@@ -10,11 +10,28 @@
   *    Tim Shearouse - initial API and implementation
   *******************************************************************************/
 using AgGateway.ADAPT.Representation.UnitSystem.ExtensionMethods;
+using System;
+using System.IO;
+using System.Reflection;
 
 namespace AgGateway.ADAPT.Representation.UnitSystem
 {
     public static class UnitSystemManager
     {
+        private static string unitSystemDataLocation = null;
+        public static string UnitSystemDataLocation {
+            get {
+                if (unitSystemDataLocation == null) {
+                    var assemblyLocation = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
+                    var repSystemXml = Path.Combine(assemblyLocation, "Resources", "UnitSystem.xml");
+                    return repSystemXml;
+                } else {
+                    return unitSystemDataLocation;
+                }
+            }
+            set { unitSystemDataLocation = value; }
+        }
+
         public static ApplicationDataModel.Common.UnitOfMeasure GetUnitOfMeasure(string code)
         {
             return InternalUnitSystemManager.Instance.UnitOfMeasures[code].ToModelUom();


### PR DESCRIPTION
While working on a web-based project, we ran into issues with the way that the XML files used by the Representation library are discovered. Because of the nature of the project, it was impossible to write these files to the directory expected by the runtime.

These changes should help to alleviate issues similar to this. I've added public static properties for manually specifying the location of each XML file. These properties are completely optional, and if left untouched, will not change the current behavior of resource location, thus making the change backwards compatible.

To configure the location of these files, all that's required is to ensure that the following code runs before the first instantiation of either the RepresentationManager or InternalUnitSystemManager (typically in your Startup.cs or other such initialization code.)

`RepresentationManager.RepresentationSystemDataLocation = <full-path-to-RepresentationSystem.xml>;`
`UnitSystemManager.UnitSystemDataLocation = <full-path-to-UnitSystem.xml>;`
