### PR TITLE
Removed duplicate locale for NL in the unit system xml

### DIFF
--- a/source/Representation/Resources/UnitSystem.xml
+++ b/source/Representation/Resources/UnitSystem.xml
@@ -1335,7 +1335,6 @@
 					<Name locale="fr" label="°F" plural="Fahrenheit">Fahrenheit</Name>
 					<Name locale="da" label="°F" plural="fahrenheit">fahrenheit</Name>
 					<Name locale="nl" label="°F" plural="fahrenheit">fahrenheit</Name>
-					<Name locale="nl" label="°F" plural="fahrenheit">fahrenheit</Name>
 					<Name locale="es" label="°F" plural="fahrenheit">fahrenheit</Name>
 					<Name locale="it" label="°F" plural="fahrenheit">fahrenheit</Name>
 					<Name locale="pt" label="°F" plural="fahrenheit">fahrenheit</Name>


### PR DESCRIPTION
Signed-off-by: Tim Shearouse <ShearouseTimothyW@JohnDeere.com>

This was causing an error when using ADAPT on a computer set to use Dutch.