### PR TITLE
Revert resource file location code to same as v1.2

### DIFF
--- a/AgGatewayADAPTFramework.nuspec
+++ b/AgGatewayADAPTFramework.nuspec
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package
-  xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>AgGatewayADAPTFramework</id>
     <version>0.0.0</version>
@@ -10,7 +9,7 @@
     <projectUrl>https://github.com/ADAPT/ADAPT</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>AgGateway ADAPT framework</description>
-    <copyright>Copyright (C) 2015-18 AgGateway and ADAPT Contributors</copyright>
+    <copyright>Copyright (C) 2015-19 AgGateway and ADAPT Contributors</copyright>
     <tags>aggateway adapt agriculture</tags>
     <references>
       <reference file="AgGateway.ADAPT.ApplicationDataModel.dll"/>

--- a/source/ADAPT/ApplicationDataModel.csproj
+++ b/source/ADAPT/ApplicationDataModel.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>AgGateway.ADAPT.ApplicationDataModel</AssemblyName>
     <RootNamespace>AgGateway.ADAPT.ApplicationDataModel</RootNamespace>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <Copyright>Copyright (C) 2015-18 AgGateway and ADAPT Contributors</Copyright>
+    <Copyright>Copyright (C) 2015-19 AgGateway and ADAPT Contributors</Copyright>
   </PropertyGroup>
 
 </Project>

--- a/source/ApplicationDataModelTest/ApplicationDataModelTest.csproj
+++ b/source/ApplicationDataModelTest/ApplicationDataModelTest.csproj
@@ -10,7 +10,7 @@
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <Version>0.0.0</Version>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <Copyright>Copyright (C) 2015-18 AgGateway and ADAPT Contributors</Copyright>
+    <Copyright>Copyright (C) 2015-19 AgGateway and ADAPT Contributors</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/PluginManager/PluginManager.csproj
+++ b/source/PluginManager/PluginManager.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>AgGateway.ADAPT.PluginManager</AssemblyName>
     <RootNamespace>AgGateway.ADAPT.PluginManager</RootNamespace>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <Copyright>Copyright (C) 2015-18 AgGateway and ADAPT Contributors</Copyright>
+    <Copyright>Copyright (C) 2015-19 AgGateway and ADAPT Contributors</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/PluginManagerTest/PluginManagerTest.csproj
+++ b/source/PluginManagerTest/PluginManagerTest.csproj
@@ -9,7 +9,7 @@
     <Company>AgGateway</Company>
     <Product>ADAPT</Product>
     <NeutralLanguage>English (United States)</NeutralLanguage>
-    <Copyright>Copyright (C) 2015-18 AgGateway and ADAPT Contributors</Copyright>
+    <Copyright>Copyright (C) 2015-19 AgGateway and ADAPT Contributors</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Representation/Representation.csproj
+++ b/source/Representation/Representation.csproj
@@ -9,7 +9,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <AssemblyName>AgGateway.ADAPT.Representation</AssemblyName>
     <RootNamespace>AgGateway.ADAPT.Representation</RootNamespace>
-    <Copyright>Copyright (C) 2015-18 AgGateway and ADAPT Contributors</Copyright>
+    <Copyright>Copyright (C) 2015-19 AgGateway and ADAPT Contributors</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Representation/RepresentationSystem/RepresentationManager.cs
+++ b/source/Representation/RepresentationSystem/RepresentationManager.cs
@@ -4,7 +4,7 @@
   * All rights reserved. This program and the accompanying materials
   * are made available under the terms of the Eclipse Public License v1.0
   * which accompanies this distribution, and is available at
-  * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+  * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html>
   *
   * Contributors:
   *    Tarak Reddy, Tim Shearouse - initial API and implementation
@@ -17,63 +17,70 @@ using System.Xml.Serialization;
 
 namespace AgGateway.ADAPT.Representation.RepresentationSystem
 {
-    public class RepresentationManager
+  public class RepresentationManager
+  {
+    private static RepresentationManager _instance;
+    private static readonly object BlueThreadLock = new Object();
+
+    private static string _representationSystemDataLocation = null;
+
+    public static string RepresentationSystemDataLocation
     {
-        private static RepresentationManager _instance;
-        private static readonly object BlueThreadLock = new Object();
-
-        private static string representationSystemDataLocation = null;
-
-        public static string RepresentationSystemDataLocation {
-            get {
-                if(representationSystemDataLocation == null) {
-                    var assemblyLocation = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
-                    var repSystemXml = Path.Combine(assemblyLocation, "Resources", "RepresentationSystem.xml");
-                    return repSystemXml;
-                } else {
-                    return representationSystemDataLocation;
-                }
-            }
-            set { representationSystemDataLocation = value; }
-        }
-
-        public static RepresentationManager Instance
+      get
+      {
+        if (_representationSystemDataLocation == null)
         {
-            get
-            {
-                if(_instance == null)
-                    lock (BlueThreadLock)
-                    {
-                        if (_instance == null)
-                            _instance = new RepresentationManager();
-                    }
-                return _instance;
-            }
+          var assemblyLocation = AppDomain.CurrentDomain.BaseDirectory;
+          var repSystemXml = Path.Combine(assemblyLocation, "Resources", "RepresentationSystem.xml");
+          return repSystemXml;
         }
-
-        public RepresentationCollection<Representation> Representations { get; private set; }
-
-        private RepresentationManager()
+        else
         {
-            var representationSystem = DeserializeRepresentationSystem();
-            Representations = GetRepresentations(representationSystem);
+          return _representationSystemDataLocation;
         }
-
-        private static RepresentationCollection<Representation> GetRepresentations(Generated.RepresentationSystem representationSystem)
-        {
-            var numericRepresentations = representationSystem.Representations.NumericRepresentation.Select(v => new NumericRepresentation(v));
-            var enumeratedRepresentations = representationSystem.Representations.EnumeratedRepresentation.Select(d => new EnumeratedRepresentation(d));
-            var allRepresentations = numericRepresentations.Union<Representation>(enumeratedRepresentations);
-            return new RepresentationCollection<Representation>(allRepresentations);
-        } 
-
-        private static Generated.RepresentationSystem DeserializeRepresentationSystem()
-        {
-            var serializer = new XmlSerializer(typeof(Generated.RepresentationSystem));
-
-            var xmlStringBytes = File.ReadAllBytes(RepresentationSystemDataLocation);
-            using (var stream = new MemoryStream(xmlStringBytes))
-                return (Generated.RepresentationSystem)serializer.Deserialize(stream);
-        }
+      }
+      set { _representationSystemDataLocation = value; }
     }
+
+    public static RepresentationManager Instance
+    {
+      get
+      {
+        if (_instance == null)
+          lock (BlueThreadLock)
+          {
+            if (_instance == null)
+              _instance = new RepresentationManager();
+          }
+        return _instance;
+      }
+    }
+
+    public RepresentationCollection<Representation> Representations { get; private set; }
+
+    private RepresentationManager()
+    {
+      var representationSystem = DeserializeRepresentationSystem();
+      Representations = GetRepresentations(representationSystem);
+    }
+
+    private static RepresentationCollection<Representation> GetRepresentations(Generated.RepresentationSystem representationSystem)
+    {
+      var numericRepresentations = representationSystem.Representations.NumericRepresentation.Select(v => new NumericRepresentation(v));
+      var enumeratedRepresentations = representationSystem.Representations.EnumeratedRepresentation.Select(d => new EnumeratedRepresentation(d));
+      var allRepresentations = numericRepresentations.Union<Representation>(enumeratedRepresentations);
+      return new RepresentationCollection<Representation>(allRepresentations);
+    }
+
+    private static Generated.RepresentationSystem DeserializeRepresentationSystem()
+    {
+      var serializer = new XmlSerializer(typeof(Generated.RepresentationSystem));
+
+      var xmlStringBytes = File.ReadAllBytes(RepresentationSystemDataLocation);
+      using (var stream = new MemoryStream(xmlStringBytes))
+      {
+        return (Generated.RepresentationSystem)serializer.Deserialize(stream);
+      }
+    }
+  }
 }

--- a/source/Representation/UnitSystem/UnitSystemManager.cs
+++ b/source/Representation/UnitSystem/UnitSystemManager.cs
@@ -4,7 +4,7 @@
   * All rights reserved. This program and the accompanying materials
   * are made available under the terms of the Eclipse Public License v1.0
   * which accompanies this distribution, and is available at
-  * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+  * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html>
   *
   * Contributors:
   *    Tim Shearouse - initial API and implementation
@@ -16,36 +16,42 @@ using System.Reflection;
 
 namespace AgGateway.ADAPT.Representation.UnitSystem
 {
-    public static class UnitSystemManager
+  public static class UnitSystemManager
+  {
+    private static string _unitSystemDataLocation = null;
+
+    public static string UnitSystemDataLocation
     {
-        private static string unitSystemDataLocation = null;
-        public static string UnitSystemDataLocation {
-            get {
-                if (unitSystemDataLocation == null) {
-                    var assemblyLocation = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
-                    var repSystemXml = Path.Combine(assemblyLocation, "Resources", "UnitSystem.xml");
-                    return repSystemXml;
-                } else {
-                    return unitSystemDataLocation;
-                }
-            }
-            set { unitSystemDataLocation = value; }
-        }
-
-        public static ApplicationDataModel.Common.UnitOfMeasure GetUnitOfMeasure(string code)
+      get
+      {
+        if (_unitSystemDataLocation == null)
         {
-            return InternalUnitSystemManager.Instance.UnitOfMeasures[code].ToModelUom();
+          var assemblyLocation = AppDomain.CurrentDomain.BaseDirectory;
+          var repSystemXml = Path.Combine(assemblyLocation, "Resources", "UnitSystem.xml");
+          return repSystemXml;
         }
-
-        public static ApplicationDataModel.Common.UnitOfMeasure FromUNRec20Code(string code)
+        else
         {
-            var domainId = InternalUnitSystemManager.Instance.UnRec20CodeToDomainId[code];
-            return GetUnitOfMeasure(domainId);
+          return _unitSystemDataLocation;
         }
-
-        public static string GetUNRec20Code(ApplicationDataModel.Common.UnitOfMeasure uom)
-        {
-            return InternalUnitSystemManager.Instance.DomainIdToUnRec20Code[uom.Code];
-        }
+      }
+      set { _unitSystemDataLocation = value; }
     }
+
+    public static ApplicationDataModel.Common.UnitOfMeasure GetUnitOfMeasure(string code)
+    {
+      return InternalUnitSystemManager.Instance.UnitOfMeasures[code].ToModelUom();
+    }
+
+    public static ApplicationDataModel.Common.UnitOfMeasure FromUNRec20Code(string code)
+    {
+      var domainId = InternalUnitSystemManager.Instance.UnRec20CodeToDomainId[code];
+      return GetUnitOfMeasure(domainId);
+    }
+
+    public static string GetUNRec20Code(ApplicationDataModel.Common.UnitOfMeasure uom)
+    {
+      return InternalUnitSystemManager.Instance.DomainIdToUnRec20Code[uom.Code];
+    }
+  }
 }

--- a/source/RepresentationTest/RepresentationTest.csproj
+++ b/source/RepresentationTest/RepresentationTest.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>AgGateway.ADAPT.RepresentationTest</RootNamespace>
     <AssemblyName>AgGateway.ADAPT.RepresentationTest</AssemblyName>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <Copyright>Copyright (C) 2015-18 AgGateway and ADAPT Contributors</Copyright>
+    <Copyright>Copyright (C) 2015-19 AgGateway and ADAPT Contributors</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/TestPlugin/TestPlugin.csproj
+++ b/source/TestPlugin/TestPlugin.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>AgGateway.ADAPT.TestPlugin</AssemblyName>
     <RootNamespace>AgGateway.ADAPT.TestPlugin</RootNamespace>
     <AssemblyVersion>0.0.0.0</AssemblyVersion>
-    <Copyright>Copyright (C) 2015-18 AgGateway and ADAPT Contributors</Copyright>
+    <Copyright>Copyright (C) 2015-19 AgGateway and ADAPT Contributors</Copyright>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
While adding in the code to specify an overridden location for the resource files required for representations and units the default resource file location was changed. This stops the ADAPT framework working on .NET Core. I've reverted this back to the same code used in the v1.2 release.

Additional I've updated the copyrights to *Copyright (C) 2015-19 AgGateway and ADAPT Contributors* and any modified files have also had their formatting automatically updated to use the projects `.editorconfig` settings.