### PR TITLE
Add MixOrder to ProductComponent

### DIFF
--- a/source/ADAPT/Products/ProductComponent.cs
+++ b/source/ADAPT/Products/ProductComponent.cs
@@ -1,6 +1,7 @@
 ﻿/*******************************************************************************
   * Copyright (C) 2015 AgGateway and ADAPT Contributors
   * Copyright (C) 2015 Deere and Company
+  * Copyright (C) 2019 Syngenta
   * All rights reserved. This program and the accompanying materials
   * are made available under the terms of the Eclipse Public License v1.0
   * which accompanies this distribution, and is available at
@@ -8,6 +9,7 @@
   *
   * Contributors:
   *    Tim Shearouse - initial API and implementation
+  *    R. Andres Ferreyra - Added MixOrder, as requested for Mix Ticket "Product Group" compatibility.
   *******************************************************************************/
 
 using AgGateway.ADAPT.ApplicationDataModel.Representations;
@@ -23,5 +25,8 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Products
         public bool IsProduct { get; set; }
 
         public bool IsCarrier { get; set; }
+        
+        public int? MixOrder { get; set; } // In what order was this component added to the mix? (1 = First).
+        // Can have duplicate numbers, representing a situation where two or more components are added simultaneously.
     }
 }


### PR DESCRIPTION
Doug Applegate from the Mix Ticket group informed me that the order in which products are added to a mix is sometimes very important, in which case it becomes a property that should be kept track of. Implementing that through a nullable integer properly, MixOrder.