### PR TITLE
Adding PAIL's OMCodeComponentPartEnum and OMCodeComponentValueTypeEnum

### DIFF
--- a/source/ADAPT/Documents/OMCodeComponentPartEnum.cs
+++ b/source/ADAPT/Documents/OMCodeComponentPartEnum.cs
@@ -1,0 +1,23 @@
+/*******************************************************************************
+  * Copyright (C) 2019 AgGateway, ADAPT Contributors, and Syngenta
+  * All rights reserved. This program and the accompanying materials
+  * are made available under the terms of the Eclipse Public License v1.0
+  * which accompanies this distribution, and is available at
+  * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+  *
+  * Contributors:
+  * 4/16/2019 R. Andres Ferreyra created the class transcribing from the X632-2 Observations schema.   
+  *    
+  *******************************************************************************/
+
+namespace AgGateway.ADAPT.ApplicationDataModel.Documents
+{
+    public enum OMCodeComponentPartEnum // Describes what part of a CodeComponent is being described by an OMEnumItem.
+    {
+        ComponentType, // The OMEnumItem describes a CodeComponent.CodeComponentType. 
+        Selector,      // The OMEnumItem describes a CodeComponent.CodeComponentSelector. 
+        Value,         // The OMEnumItem describes a CodeComponent.CodeComponentValue. 
+        UoM            // The OMEnumItem describes a CodeComponent.CodeComponentUoM.
+    }
+
+}

--- a/source/ADAPT/Documents/OMCodeComponentValueTypeEnum.cs
+++ b/source/ADAPT/Documents/OMCodeComponentValueTypeEnum.cs
@@ -1,0 +1,25 @@
+/*******************************************************************************
+  * Copyright (C) 2019 AgGateway, ADAPT Contributors, and Syngenta
+  * All rights reserved. This program and the accompanying materials
+  * are made available under the terms of the Eclipse Public License v1.0
+  * which accompanies this distribution, and is available at
+  * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+  *
+  * Contributors:
+  * 4/16/2019 R. Andres Ferreyra created the class transcribing from the X632-2 Observations schema.   
+  *    
+  *******************************************************************************/
+
+namespace AgGateway.ADAPT.ApplicationDataModel.Documents
+{
+    public enum OMCodeComponentValueTypeEnum // Specifies the data type represented by an OMCodeComponent value (string).
+    {
+        Enum,    // The value is a token, and comes from a code list. 
+        Bool,    // The value should be interpreted as an XML-formatted boolean.
+        String,  // The value should be interpreted as a string. 
+        Double,  // The value should be interpreted as a floating-point number. 
+        Integer, // The value should be interpreted as an integer. 
+        DateTime // The value should be interpreted as an XML-formatted DateTime.
+    }
+
+}


### PR DESCRIPTION
Transcription of two simple types from PAIL:
OMCodeComponentPartEnum: Names the four parts of an OMCodeComponent
OMCodeComponentValueTypeEnum: Indicates what data type the value string of a code component should be interpreted as.

Both of these classes were submitted (and approved) on 4/16/19, but I had to rename them following a pull request snafu.