### PR TITLE
Adding OMCode

### DIFF
--- a/source/ADAPT/Documents/OMCode.cs
+++ b/source/ADAPT/Documents/OMCode.cs
@@ -26,7 +26,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Documents
         public string Code { get; set; }
         public string PId { get; set; }
         public string Description { get; set; }
-        public List<int> CodeComponentsIds { get; set; }       
+        public List<int> CodeComponentIds { get; set; }       
         public List<ContextItem> ContextItems { get; set; }       
     }
 }

--- a/source/ADAPT/Documents/OMCode.cs
+++ b/source/ADAPT/Documents/OMCode.cs
@@ -24,7 +24,6 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Documents
         }
         public CompoundIdentifier Id { get; private set; }
         public string Code { get; set; }
-        public string PId { get; set; }
         public string Description { get; set; }
         public List<int> CodeComponentIds { get; set; }       
         public List<ContextItem> ContextItems { get; set; }       

--- a/source/ADAPT/Documents/OMCode.cs
+++ b/source/ADAPT/Documents/OMCode.cs
@@ -6,6 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
  *
  * Contributors: 20190430 R. Andres Ferreyra: Translate from PAIL Part 2 Schema
+ *               20190710 R. Andres Ferreyra: Added documentation
  *    
  *******************************************************************************/
 
@@ -14,18 +15,19 @@ using AgGateway.ADAPT.ApplicationDataModel.Common;
 
 namespace AgGateway.ADAPT.ApplicationDataModel.Documents
 {
-    public class OMCode
+    public class OMCode // Go-to way of expressing the meaning of an Obs (observation)
     {
         public OMCode()
         {
             Id = CompoundIdentifierFactory.Instance.Create();
-            CodeComponentIds = new List<int>();
+            CodeComponentIds = new List<int>(); 
             ContextItems = new List<ContextItem>();
         }
-        public CompoundIdentifier Id { get; private set; }
-        public string Code { get; set; }
-        public string Description { get; set; }
-        public List<int> CodeComponentIds { get; set; }       
+        public CompoundIdentifier Id { get; private set; } // Each OmCode has its own CompoundIdentifier
+        public string Code { get; set; }  // This is the key for key,value representations of an observation. 
+        public string Description { get; set; } // Human-readable description of what the OMCode means.
+        public List<int> CodeComponentIds { get; set; } // These are the units of meaning stat specify aspects of the OMCode's
+          // meaning, such as feature of interest, observed property, observation method, aggregation method, etc.
         public List<ContextItem> ContextItems { get; set; }       
     }
 }

--- a/source/ADAPT/Documents/OMCode.cs
+++ b/source/ADAPT/Documents/OMCode.cs
@@ -5,9 +5,12 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
  *
- * Contributors: R. Andres Ferreyra: Translate from PAIL Part 2 Schema
+ * Contributors: 20190430 R. Andres Ferreyra: Translate from PAIL Part 2 Schema
  *    
  *******************************************************************************/
+
+using System.Collections.Generic;
+using AgGateway.ADAPT.ApplicationDataModel.Common;
 
 namespace AgGateway.ADAPT.ApplicationDataModel.Documents
 {

--- a/source/ADAPT/Documents/OMCode.cs
+++ b/source/ADAPT/Documents/OMCode.cs
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (C) 2019 AgGateway; PAIL and ADAPT Contributors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+ *
+ * Contributors: R. Andres Ferreyra: Translate from PAIL Part 2 Schema
+ *    
+ *******************************************************************************/
+
+namespace AgGateway.ADAPT.ApplicationDataModel.Documents
+{
+    public class OMCode
+    {
+        public OMCode()
+        {
+            Id = CompoundIdentifierFactory.Instance.Create();
+            CodeComponentIds = new List<int>();
+            ContextItems = new List<ContextItem>();
+        }
+        public CompoundIdentifier Id { get; private set; }
+        public string Code { get; set; }
+        public string PId { get; set; }
+        public string Description { get; set; }
+        public List<int> CodeComponentsIds { get; set; }       
+        public List<ContextItem> ContextItems { get; set; }       
+    }
+}


### PR DESCRIPTION
Fundamental part of ISO 19156 implementation in PAIL; enables conveying the meaning of an observation via a single code, and reducing the observation to a key-value pair. (Note: This is not the only way to represent meaning in PAIL; it's just the most compact form.)