### PR TITLE
Add O&M support to Load

### DIFF
--- a/source/ADAPT/LoggedData/Load.cs
+++ b/source/ADAPT/LoggedData/Load.cs
@@ -1,6 +1,7 @@
 /*******************************************************************************
   * Copyright (C) 2015, 2018, 2019 AgGateway and ADAPT Contributors
   * Copyright (C) 2015 Deere and Company
+  * Copyright (C) 2019 Syngenta  
   * All rights reserved. This program and the accompanying materials
   * are made available under the terms of the Eclipse Public License v1.0
   * which accompanies this distribution, and is available at
@@ -12,7 +13,8 @@
   *    Justin Sliekers - udpating DestinationId to collection and changed loadtype from EnumeratedRepresentation to LoadTypeEnum
   *    R. Andres Ferreyra - fixing typo: renaming LoadQuality to LoadQuantity. Adding QUALITY attributes (i.e, OMs) can wait to v2.1
   *    R. Andres Ferreyra - fixing bug: TimeScopes are used by value in ADAPT, not by reference. Changing accordingly.
-  *    R. Andres Ferreyra - Adding list of ContextItems, to accommodate USDA-specific attributes for cotton. 
+  *    R. Andres Ferreyra - Adding list of ContextItems, to accommodate USDA-specific attributes for cotton.
+  *    20190430 R. Andres Ferreyra - Adding reference to an Observations document.
   *******************************************************************************/
 
 
@@ -47,5 +49,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.LoggedData
         public List<int> DestinationIds { get; set; }
         
         public List<ContextItem> ContextItems { get; set; }
+        
+        public int? ObservationsId { get; set; } // 20190430 Added O&M support
     }
 }


### PR DESCRIPTION
Adds a reference to an Observations document to the Load class. This enables associating a set of observations & measurements to a Load object.