### PR TITLE
Add Place and PlaceTypeEnum

### DIFF
--- a/source/ADAPT/Logistics/Place.cs
+++ b/source/ADAPT/Logistics/Place.cs
@@ -1,0 +1,55 @@
+/*******************************************************************************
+  * Copyright (C) 2019 AgGateway, ADAPT Contributors, and Syngenta
+  * All rights reserved. This program and the accompanying materials
+  * are made available under the terms of the Eclipse Public License v1.0
+  * which accompanies this distribution, and is available at
+  * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+  *
+  * Contributors:
+  *    20190319: R. Andres Ferreyra - Created class from Traceability WG and PAIL work 
+  *******************************************************************************/
+using System.Collections.Generic;
+using AgGateway.ADAPT.ApplicationDataModel.Common;
+using AgGateway.ADAPT.ApplicationDataModel.Shapes;
+
+namespace AgGateway.ADAPT.ApplicationDataModel.Logistics
+{
+    // Place enables specifying where something is/was/will be, with varying degrees of detail.
+    // Initially planned for use when specifying actions performed with containers, and With PAIL OM.
+
+    public class Place
+    {
+        public Place()
+        {
+            Id = CompoundIdentifierFactory.Instance.Create();
+            ContextItems = new List<ContextItem>();
+        }
+
+        public CompoundIdentifier Id { get; private set; }
+
+        public string Description { get; set; }
+ 
+        /// <summary>
+        /// PlaceType property. </summary>
+        /// <value>
+        /// This declares what class the Place is standing in for (e.g., Position, Container, etc. This value is required. Note that "Mixed" is an option.</value>
+        public PlaceTypeEnum PlaceType { get; set; }
+
+        public int? DeviceElementId { get; set; }
+        public int? ContainerId { get; set; }
+        public int? FarmId { get; set; }
+        public int? FieldId { get; set; }
+        public int? CropZoneId { get; set; }
+        public int? FacilityId { get; set; }
+        public MultiPolygon MultiPolygon { get; set; }
+        public LineString LineString { get; set; }
+        public Location Location { get; set; }
+        public Point Position { get; set; }
+
+        /// <summary>
+        /// ContextItems property. </summary>
+        /// <value>
+        /// Optional list of ContextItem objects.</value>
+        public List<ContextItem> ContextItems { get; set; }
+    }
+}

--- a/source/ADAPT/Logistics/Place.cs
+++ b/source/ADAPT/Logistics/Place.cs
@@ -35,16 +35,13 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Logistics
         /// This declares what class the Place is standing in for (e.g., Position, Container, etc. This value is required. Note that "Mixed" is an option.</value>
         public PlaceTypeEnum PlaceType { get; set; }
 
-        public int? DeviceElementId { get; set; }
-        public int? ContainerId { get; set; }
+        public int? DeviceElementId { get; set; } // Allows associating an observation or ProductContainerOperation to a DeviceElement
+        public int? ContainerId { get; set; } // Allows associating an observation or ProductContainerOperation to a Container
         public int? FarmId { get; set; }
         public int? FieldId { get; set; }
         public int? CropZoneId { get; set; }
         public int? FacilityId { get; set; }
-        public MultiPolygon MultiPolygon { get; set; }
-        public LineString LineString { get; set; }
-        public Location Location { get; set; }
-        public Point Position { get; set; }
+        public Location Location { get; set; } // Enables using Locations by reference, like in PAIL and ISO 19112.
 
         /// <summary>
         /// ContextItems property. </summary>

--- a/source/ADAPT/Logistics/PlaceTypeEnum.cs
+++ b/source/ADAPT/Logistics/PlaceTypeEnum.cs
@@ -1,0 +1,30 @@
+/*******************************************************************************
+  * Copyright (C) 2019 AgGateway, ADAPT Contributors
+  * All rights reserved. This program and the accompanying materials
+  * are made available under the terms of the Eclipse Public License v1.0
+  * which accompanies this distribution, and is available at
+  * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+  *
+  * Contributors:
+  * 20190319: R. Andres Ferreyra created the class from PAIL and Traceability WG work.  
+  *    
+  *******************************************************************************/
+
+namespace AgGateway.ADAPT.ApplicationDataModel.Logistics
+{
+    public enum PlaceTypeEnum
+    {
+        Position, // This case produces a Place that is functionally equivalent to a PAIL Location. 
+        LineString, // Enables PAIL's LineString feature-of-interest
+        MultiPolygon, // Enables PAIL's MultiPolygon feature-of-interest
+        Location,
+        Facility,
+        DeviceElement,
+        Container, 
+        Farm,
+        Field,        
+        CropZone,
+        Mixed // Enables "adding what you know"; when there may be position, farm & field, for example.        
+    }
+
+}

--- a/source/ADAPT/Logistics/PlaceTypeEnum.cs
+++ b/source/ADAPT/Logistics/PlaceTypeEnum.cs
@@ -14,10 +14,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Logistics
 {
     public enum PlaceTypeEnum
     {
-        Position, // This case produces a Place that is functionally equivalent to a PAIL Location. 
-        LineString, // Enables PAIL's LineString feature-of-interest
-        MultiPolygon, // Enables PAIL's MultiPolygon feature-of-interest
-        Location,
+        Location, // This case produces a Place that is functionally equivalent to a PAIL / ISO 19112 Location. 
         Facility,
         DeviceElement,
         Container, 


### PR DESCRIPTION
Put, under a single umbrella class, all the different kinds of "places" (with different levels of specificity thereof) where an operation (observation, transfer, transport, etc) may take place, Adds a CompoundIdentifier, and encapsulates the full range from Position (which, given the identifier, becomes compatible with the PAIL Location class), Location, Facility, DeviceElement, Container, Farm, Field, CropZone, MultiLine, and MultiPolygon.