### PR TITLE
Update connector type list

### DIFF
--- a/source/ADAPT/Equipment/ConnectorTypeEnum.cs
+++ b/source/ADAPT/Equipment/ConnectorTypeEnum.cs
@@ -24,7 +24,6 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Equipment
         ISO64894PitonTypeCoupling,
         ISO56922PivotWagonHitch,
         ISO24347BallTypeHitch,
-
-        ChassisMountedSelfPropelled
+        ChassisMountedSelfPropelled,
     }
 }

--- a/source/ADAPT/Equipment/ConnectorTypeEnum.cs
+++ b/source/ADAPT/Equipment/ConnectorTypeEnum.cs
@@ -24,5 +24,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Equipment
         ISO64894PitonTypeCoupling,
         ISO56922PivotWagonHitch,
         ISO24347BallTypeHitch,
+
+        ChassisMountedSelfPropelled
     }
 }


### PR DESCRIPTION
This list was created in 2016 and was - back than - compatible with ISO11783 DDI 157 "ConnectorType".
ConnectorTypeList was updated in 2018; see https://www.isobus.net/isobus/dDEntity/767
This Pullrequest simply adds the missing new entry