### PR TITLE
Adding ObsCollection reference to Load

### DIFF
--- a/source/ADAPT/LoggedData/Load.cs
+++ b/source/ADAPT/LoggedData/Load.cs
@@ -15,6 +15,7 @@
   *    R. Andres Ferreyra - fixing bug: TimeScopes are used by value in ADAPT, not by reference. Changing accordingly.
   *    R. Andres Ferreyra - Adding list of ContextItems, to accommodate USDA-specific attributes for cotton.
   *    20190430 R. Andres Ferreyra - Adding reference to an Observations document.
+  *    20190819 R. Andres Ferreyra - Adding reference to an ObsCollection object (assumed within the Observations document).
   *******************************************************************************/
 
 
@@ -51,5 +52,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.LoggedData
         public List<ContextItem> ContextItems { get; set; }
         
         public int? ObservationsId { get; set; } // 20190430 Added O&M support
+        
+        public int? ObsCollectionId { get; set; } // 20190819 Added reference to a specific ObsCollection to hold this load's observations
     }
 }


### PR DESCRIPTION
Supporting the use case where a set of loads (e.g., a USDA report coming ffrom a cotton gin that describes multiple bales; a set of railroad cars loaded with grain coming to an elevator) has a collection of observations per load (e.g., staple length, micronaire, color, etc. for cotton; moisture, protein content, etc. for grain). It's natural for all the observations in that shipment to fall within a single Observations document (already supported), but it's reasonable for each Load's observations to be held within a specific ObsCollection, so the observations for each Load can be told apart. The reference to an ObsCollectionId added in this pull request enables this.