### PR TITLE
Using Interlocked.Decrement in CompoundIdentifierFactory, as it's faster than normal locks.

### DIFF
--- a/source/ADAPT/ADM/Catalog.cs
+++ b/source/ADAPT/ADM/Catalog.cs
@@ -66,7 +66,6 @@ namespace AgGateway.ADAPT.ApplicationDataModel.ADM
             DeviceElements = new List<DeviceElement>();
             HitchPoints = new List<HitchPoint>();
             Companies = new List<Company>();
-            Products = new List<Product>();
             Places = new List<Place>();
         }
 

--- a/source/ADAPT/Common/CompoundIdentifierFactory.cs
+++ b/source/ADAPT/Common/CompoundIdentifierFactory.cs
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
   * Copyright (C) 2015 AgGateway and ADAPT Contributors
   * Copyright (C) 2015 Deere and Company
   * All rights reserved. This program and the accompanying materials
@@ -11,6 +11,7 @@
   *******************************************************************************/
 
 using System.Collections.Generic;
+using System.Threading;
 
 namespace AgGateway.ADAPT.ApplicationDataModel.Common
 {
@@ -19,7 +20,6 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Common
         private static CompoundIdentifierFactory _instance;
         private static int _lowestReferenceId;
         private static readonly object InstanceThreadLock = new object();
-        private static readonly object CreateThreadLock = new object();
 
         private CompoundIdentifierFactory()
         {
@@ -44,12 +44,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Common
 
         public CompoundIdentifier Create()
         {
-            int referenceId;
-            lock (CreateThreadLock)
-            {
-                _lowestReferenceId--;
-                referenceId = _lowestReferenceId;
-            }
+            int referenceId = Interlocked.Decrement(ref _lowestReferenceId);
             return new CompoundIdentifier(referenceId)
             {
                 UniqueIds = new List<UniqueId>()


### PR DESCRIPTION
Also removed duplicate Products property in catalog.

Quick microbenchmark indicates that it's ~15% faster to acquire threadsafe decrementing values using Interlocked.Decrement rather than the current lock implementation. The thread contention shows as a hotspot when profiling our plugins.

Signed-off-by: Tim Shearouse <shearousetimothyw@johndeere.com>