### PR TITLE
Allow injecting the number of meters into SpatialRecord to avoid Dictionary resizing

### DIFF
--- a/source/ADAPT/LoggedData/SpatialRecord.cs
+++ b/source/ADAPT/LoggedData/SpatialRecord.cs
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
   * Copyright (C) 2015 AgGateway and ADAPT Contributors
   * Copyright (C) 2015 Deere and Company
   * All rights reserved. This program and the accompanying materials
@@ -21,8 +21,20 @@ namespace AgGateway.ADAPT.ApplicationDataModel.LoggedData
 {
     public class SpatialRecord
     {
-        private readonly Dictionary<int, RepresentationValue> _meterValues = new Dictionary<int, RepresentationValue>(); 
-        private readonly Dictionary<int, int?> _appliedLatencyValues = new Dictionary<int, int?>(); 
+        private readonly Dictionary<int, RepresentationValue> _meterValues; 
+        private readonly Dictionary<int, int?> _appliedLatencyValues;
+
+        public SpatialRecord()
+        {
+            _meterValues = new Dictionary<Int32, RepresentationValue>();
+            _appliedLatencyValues = new Dictionary<Int32,Int32?>();
+        }
+
+        public SpatialRecord(int numberOfMeters)
+        {
+            _meterValues = new Dictionary<Int32,RepresentationValue>(numberOfMeters);
+            _appliedLatencyValues = new Dictionary<Int32,Int32?>();
+        }
 
         public Shape Geometry { get; set; }
 

--- a/source/ADAPT/LoggedData/SpatialRecord.cs
+++ b/source/ADAPT/LoggedData/SpatialRecord.cs
@@ -30,6 +30,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.LoggedData
             _appliedLatencyValues = new Dictionary<Int32,Int32?>();
         }
 
+        // This overload offers a small performance improvement by avoiding dictionary resizing when calling SetMeterValue.
         public SpatialRecord(int numberOfMeters)
         {
             _meterValues = new Dictionary<Int32,RepresentationValue>(numberOfMeters);


### PR DESCRIPTION
Optional performance improvement. 

When profiling our plugins, I found that ~3-4% of the execution time was spent resizing the `_meterValues` dictionary inside SpatialRecord objects. 

Since SpatialRecords tend to be created (and to a greater degree, populated) inside a tight loop, we can gain performance by injecting the number of meters and appropriately sizing the meter dictionary. 

While measurable, this would be a very small improvement (and even then only if plugin implementers choose to use it). I'll certainly understand if the committee prefers not to merge this.