### PR TITLE
Added support to export Multiple Exterior Boundaries.

### DIFF
--- a/source/ADAPT/Products/PackagedProduct.cs
+++ b/source/ADAPT/Products/PackagedProduct.cs
@@ -22,7 +22,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Products
         public PackagedProduct()
         {
             Id = CompoundIdentifierFactory.Instance.Create();
-            ContainedPackagedProducts = new List(ContainedPackagedProduct);
+            ContainedPackagedProducts = new List<ContainedPackagedProduct>();
             ContextItems = new List<ContextItem>();
         }
 

--- a/source/ADAPT/Shapes/Polygon.cs
+++ b/source/ADAPT/Shapes/Polygon.cs
@@ -22,7 +22,7 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Shapes
             InteriorRings = new List<LinearRing>();
         }
 
-        public LinearRing ExteriorRing { get; set; }
+        public List<LinearRing> ExteriorRing { get; set; }
 
         public List<LinearRing> InteriorRings { get; set; }
     }


### PR DESCRIPTION
1. **BREAKING CHANGE** -  Added support to export Multiple Exterior Boundaries.

2. Converted `new List(ContainedPackagedProduct)` to ` new List<ContainedPackagedProduct>()` to remove compilation issues.