### PR TITLE
Adding ContextItems to Shape

### DIFF
--- a/source/ADAPT/Shapes/Shape.cs
+++ b/source/ADAPT/Shapes/Shape.cs
@@ -4,11 +4,15 @@
   * All rights reserved. This program and the accompanying materials
   * are made available under the terms of the Eclipse Public License v1.0
   * which accompanies this distribution, and is available at
-  * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html> 
+  * http://www.eclipse.org/legal/epl-v10.html <http://www.eclipse.org/legal/epl-v10.html>
   *
   * Contributors:
   *    Tarak Reddy, Tim Shearouse - initial API and implementation
+  *    Marco Bettini - added ContextItems
   *******************************************************************************/
+
+using System.Collections.Generic;
+using AgGateway.ADAPT.ApplicationDataModel.Common;
 
 namespace AgGateway.ADAPT.ApplicationDataModel.Shapes
 {
@@ -16,10 +20,13 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Shapes
     {
         protected Shape()
         {
+            ContextItems = new List<ContextItem>();
         }
 
         public int Id { get; set; }
 
         public ShapeTypeEnum Type { get; protected set; }
+
+        public List<ContextItem> ContextItems { get; set; }
     }
-} 
+}


### PR DESCRIPTION
Hello, dealing with ISOXML files we need, when present, to import the designators (attribute B) of the boundary polygons.

In order to do that, we are submitting a couple of PRs,

this one in the AdaptDataModel, to provide ContextItems field in the Shape class, 
and the other, https://github.com/ADAPT/ISOv4Plugin/pull/142, in order to populate it appropriately.