### PR TITLE
Migrate tests to .Net 5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - develop
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,7 @@ on:
 
 jobs:
   build:
-    # target 18.04 due to netcoreapp2.0 requiring OpenSSL 1.0 and newer versions of Ubuntu shipping with OpenSSL 1.1
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,6 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup .NET Core SDK '2.0'
-        uses: actions/setup-dotnet@v1.7.2
-        with:
-          dotnet-version: '2.0.x'
-      - name: Setup .NET Core SDK '3.1'
-        uses: actions/setup-dotnet@v1.7.2
-        with:
-          dotnet-version: '3.1.x'
       - name: Setup .NET '5.0'
         uses: actions/setup-dotnet@v1.7.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+      - uses: actions/checkout@v2
       - name: Setup .NET '5.0'
         uses: actions/setup-dotnet@v1.7.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
         uses: actions/setup-dotnet@v1.7.2
         with:
           dotnet-version: '3.1.x'
+      - name: Setup .NET '5.0'
+        uses: actions/setup-dotnet@v1.7.2
+        with:
+          dotnet-version: '5.0.x'
       - name: Install dependencies
         run: dotnet restore
       - name: Application Data Model Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,7 @@ on:
 
 jobs:
   build:
-    # target 18.04 due to netcoreapp2.0 requiring OpenSSL 1.0 and newer versions of Ubuntu shipping with OpenSSL 1.1
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
     - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
-  build:
+  package-and-release:
     runs-on: ubuntu-latest
 
     steps:

--- a/source/ApplicationDataModelTest/ApplicationDataModelTest.csproj
+++ b/source/ApplicationDataModelTest/ApplicationDataModelTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AssemblyName>AgGateway.ADAPT.ApplicationDataModelTest</AssemblyName>
     <RootNamespace>AgGateway.ADAPT.ApplicationDataModelTest</RootNamespace>
     <Authors>AgGateway and ADAPT Contributors</Authors>

--- a/source/PluginManagerTest/FileSystemTest.cs
+++ b/source/PluginManagerTest/FileSystemTest.cs
@@ -65,6 +65,7 @@ namespace AgGateway.ADAPT.PluginManagerTest
         [Test]
         public void GetSubDirectoriesGivenPathShouldReturnEmptyList()
         {
+            _directoryLocation = Path.Combine(_directoryLocation, Guid.NewGuid().ToString());
             var result = _fileSystem.GetSubDirectories(_directoryLocation);
             Assert.IsEmpty(result);
         }
@@ -72,6 +73,7 @@ namespace AgGateway.ADAPT.PluginManagerTest
         [Test]
         public void GetSubDirectoriesGivenPathShouldReturnTwoDirectories()
         {
+            _directoryLocation = Path.Combine(_directoryLocation, Guid.NewGuid().ToString());
             var subDirectory1 = Path.Combine(_directoryLocation, Guid.NewGuid().ToString());
             Directory.CreateDirectory(subDirectory1);
 

--- a/source/PluginManagerTest/PluginManagerTest.csproj
+++ b/source/PluginManagerTest/PluginManagerTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AssemblyName>AgGateway.ADAPT.PluginManagerTest</AssemblyName>
     <RootNamespace>AgGateway.ADAPT.PluginManagerTest</RootNamespace>
     <Version>0.0.0</Version>

--- a/source/RepresentationTest/RepresentationTest.csproj
+++ b/source/RepresentationTest/RepresentationTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Version>0.0.0</Version>
     <Authors>AgGateway and ADAPT Contributors</Authors>
     <Company>AgGateway</Company>

--- a/source/RepresentationTest/UnitSystem/UnitSystemManagerTest.cs
+++ b/source/RepresentationTest/UnitSystem/UnitSystemManagerTest.cs
@@ -129,7 +129,7 @@ namespace AgGateway.ADAPT.RepresentationTest.UnitSystem
 
         private Representation.Generated.UnitSystem DeserializeUnitSystem()
         {
-            var assemblyLocation = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
+            var assemblyLocation = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().Location).LocalPath);
             var unitSystemXml = Path.Combine(assemblyLocation, "Resources", "UnitSystem.xml");
             var serializer = new XmlSerializer(typeof(Representation.Generated.UnitSystem));
             using (var stream = File.OpenRead(unitSystemXml))


### PR DESCRIPTION
This PR addresses issue #306. The test projects now target `net5.0`. This change did require a slight modification to the FileSystem tests to properly handle how `net5.0` emits build artifacts differently than `netcoreapp2.0` but overall this change appears to be fully compatible with the existing code base.