### PR TITLE
Adapt issue 147 - Adding new representations (3 using new UoM Power)

### DIFF
--- a/source/Representation/RepresentationSystem/RepresentationInstanceList.cs
+++ b/source/Representation/RepresentationSystem/RepresentationInstanceList.cs
@@ -997,5 +997,22 @@ namespace AgGateway.ADAPT.Representation.RepresentationSystem
 
         public static readonly NumericRepresentation vrSolutionRateMassDistance = (NumericRepresentation)RepresentationManager.Instance.Representations["vrSolutionRateMassDistance"];
 
+        public static readonly NumericRepresentation vrEnginePower = (NumericRepresentation)RepresentationManager.Instance.Representations["vrEnginePower"];
+
+        public static readonly NumericRepresentation vrElectricalPowerSetPoint = (NumericRepresentation)RepresentationManager.Instance.Representations["vrElectricalPowerSetPoint"];
+
+        public static readonly NumericRepresentation vrElectricalPowerActual = (NumericRepresentation)RepresentationManager.Instance.Representations["vrElectricalPowerActual"];
+
+        public static readonly NumericRepresentation vrPTOLoadCurrentSpeed = (NumericRepresentation)RepresentationManager.Instance.Representations["vrPTOLoadCurrentSpeed"];
+
+        public static readonly NumericRepresentation vrTransmissionLoadCurrentSpeed = (NumericRepresentation)RepresentationManager.Instance.Representations["vrTransmissionLoadCurrentSpeed"];
+
+        public static readonly NumericRepresentation vrFuelTotalConsumptionEffective = (NumericRepresentation)RepresentationManager.Instance.Representations["vrFuelTotalConsumptionEffective"];
+
+        public static readonly NumericRepresentation vrFuelTotalConsumptionIneffective = (NumericRepresentation)RepresentationManager.Instance.Representations["vrFuelTotalConsumptionIneffective"];
+
+        public static readonly NumericRepresentation vrSlipCurrentSpeed = (NumericRepresentation)RepresentationManager.Instance.Representations["vrSlipCurrentSpeed"];
+
     }
+
 }

--- a/source/Representation/RepresentationSystem/RepresentationInstanceList.cs
+++ b/source/Representation/RepresentationSystem/RepresentationInstanceList.cs
@@ -1013,6 +1013,8 @@ namespace AgGateway.ADAPT.Representation.RepresentationSystem
 
         public static readonly NumericRepresentation vrSlipCurrentSpeed = (NumericRepresentation)RepresentationManager.Instance.Representations["vrSlipCurrentSpeed"];
 
+        public static readonly NumericRepresentation vrFuelProductivityTotal = (NumericRepresentation)RepresentationManager.Instance.Representations["vrFuelProductivityTotal"];
+
     }
 
 }

--- a/source/Representation/RepresentationSystem/RepresentationList.cs
+++ b/source/Representation/RepresentationSystem/RepresentationList.cs
@@ -998,5 +998,21 @@ namespace AgGateway.ADAPT.Representation.RepresentationSystem
 
         vrSolutionRateMassDistance = 555,
 
+        vrEnginePower = 559,
+
+        vrElectricalPowerSetPoint = 560,
+
+        vrElectricalPowerActual = 561,
+
+        vrPTOLoadCurrentSpeed = 562,
+
+        vrTransmissionLoadCurrentSpeed = 563,
+
+        vrFuelTotalConsumptionEffective = 564,
+
+        vrFuelTotalConsumptionIneffective = 565,
+
+        vrSlipCurrentSpeed = 566,
+
     }
 }

--- a/source/Representation/RepresentationSystem/RepresentationList.cs
+++ b/source/Representation/RepresentationSystem/RepresentationList.cs
@@ -1014,5 +1014,8 @@ namespace AgGateway.ADAPT.Representation.RepresentationSystem
 
         vrSlipCurrentSpeed = 566,
 
+        vrFuelProductivityTotal = 567,
+
+
     }
 }

--- a/source/Representation/RepresentationSystem/RepresentationTagList.cs
+++ b/source/Representation/RepresentationSystem/RepresentationTagList.cs
@@ -1012,5 +1012,7 @@ namespace AgGateway.ADAPT.Representation.RepresentationSystem
 
         public const int vrSlipCurrentSpeed = 566;
 
+        public const int vrFuelProductivityTotal = 567;
+
     }
 }

--- a/source/Representation/RepresentationSystem/RepresentationTagList.cs
+++ b/source/Representation/RepresentationSystem/RepresentationTagList.cs
@@ -996,5 +996,21 @@ namespace AgGateway.ADAPT.Representation.RepresentationSystem
 
         public const int vrSolutionRateMassDistance = 555;
 
+        public const int vrEnginePower = 559;
+
+        public const int vrElectricalPowerSetPoint = 560;
+
+        public const int vrElectricalPowerActual = 561;
+
+        public const int vrPTOLoadCurrentSpeed = 562;
+
+        public const int vrTransmissionLoadCurrentSpeed = 563;
+
+        public const int vrFuelTotalConsumptionEffective = 564;
+
+        public const int vrFuelTotalConsumptionIneffective = 565;
+
+        public const int vrSlipCurrentSpeed = 566;
+
     }
 }

--- a/source/Representation/Resources/RepresentationSystem.xml
+++ b/source/Representation/Resources/RepresentationSystem.xml
@@ -16180,7 +16180,7 @@
 			<Name locale="vi" description="TillagePressureActual">tillage pressure Actual</Name>
 		</NumericRepresentation>
 		<NumericRepresentation domainID="vrFuelProductivity" domainTag="370" digits="3" decimal="2">
-			<RelatedDDI ddi="278" unitOfMeasure="[mm3]1[m2]-1" resolution="1" offset="0"/>
+			<RelatedDDI ddi="150" unitOfMeasure="[mm3]1[m2]-1" resolution="1" offset="0"/>
 			<UnitOfMeasureDefault unitOfMeasure="gal1ac-1" digits="5" decimal="1" minValue="0" maxValue="99999.9" unitOfMeasureSystem="umsEnglish"/>
 			<UnitOfMeasureDefault unitOfMeasure="l1ha-1" digits="5" decimal="1" minValue="0" maxValue="99999.9" unitOfMeasureSystem="umsMetric"/>
 			<UnitOfMeasureDefault unitOfMeasure="igal1ac-1" digits="5" decimal="1" minValue="0" maxValue="99999.9" unitOfMeasureSystem="umsImperial"/>
@@ -17808,6 +17808,40 @@
 			<UnitOfMeasureDefault unitOfMeasure="prcnt" digits="3" decimal="2" minValue="0" maxValue="250" unitOfMeasureSystem="umsImperial"/>
 			<UnitDimensionRef unitDimension="utPercent"/>
 			<Name locale="en" description="Slip at Current Speed">Slip at Current Speed</Name>
+		</NumericRepresentation>
+		<NumericRepresentation domainID="vrFuelProductivityTotal" domainTag="567" digits="3" decimal="2">
+			<RelatedDDI ddi="278" unitOfMeasure="[mm3]1[m2]-1" resolution="1" offset="0"isDefaultRepresentationForDDI="true"/>
+			<UnitOfMeasureDefault unitOfMeasure="gal1ac-1" digits="5" decimal="1" minValue="0" maxValue="99999.9" unitOfMeasureSystem="umsEnglish"/>
+			<UnitOfMeasureDefault unitOfMeasure="l1ha-1" digits="5" decimal="1" minValue="0" maxValue="99999.9" unitOfMeasureSystem="umsMetric"/>
+			<UnitOfMeasureDefault unitOfMeasure="igal1ac-1" digits="5" decimal="1" minValue="0" maxValue="99999.9" unitOfMeasureSystem="umsImperial"/>
+			<UnitDimensionRef unitDimension="utVolumePerArea"/>
+			<Name locale="en" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="de" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="fr" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="da" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="nl" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="es" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="it" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="pt" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="ru" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="hu" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="cs" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="sk" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="fi" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="sv" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="et" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="lv" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="lt" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="no" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="pl" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="bg" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="hr" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="ro" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="tr" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="el" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="is" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="sr" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
+			<Name locale="sl" description="Fuel Productivity Total">Entire Average Fuel Consumption per Area of the device lifetime.</Name>
 		</NumericRepresentation>
 		<EnumeratedRepresentation domainID="dtApplicationMethod" domainTag="1001" attributeID="196" domainIDShort="Applicat">
 			<Name locale="en" description="ApplicationMethod">ApplicationMethod</Name>

--- a/source/Representation/Resources/RepresentationSystem.xml
+++ b/source/Representation/Resources/RepresentationSystem.xml
@@ -16180,6 +16180,7 @@
 			<Name locale="vi" description="TillagePressureActual">tillage pressure Actual</Name>
 		</NumericRepresentation>
 		<NumericRepresentation domainID="vrFuelProductivity" domainTag="370" digits="3" decimal="2">
+			<RelatedDDI ddi="278" unitOfMeasure="[mm3]1[m2]-1" resolution="1" offset="0"/>
 			<UnitOfMeasureDefault unitOfMeasure="gal1ac-1" digits="5" decimal="1" minValue="0" maxValue="99999.9" unitOfMeasureSystem="umsEnglish"/>
 			<UnitOfMeasureDefault unitOfMeasure="l1ha-1" digits="5" decimal="1" minValue="0" maxValue="99999.9" unitOfMeasureSystem="umsMetric"/>
 			<UnitOfMeasureDefault unitOfMeasure="igal1ac-1" digits="5" decimal="1" minValue="0" maxValue="99999.9" unitOfMeasureSystem="umsImperial"/>
@@ -17748,6 +17749,66 @@
 	    <UnitDimensionRef unitDimension="utMassPerDistance"/>
 	    <Name locale="en" description="Solution rate of a mass tank measured mix per distance">solution rate mass distance</Name>
 	  </NumericRepresentation>
+		<NumericRepresentation domainID="vrEnginePower" domainTag="559" digits="6" decimal="3">
+			<UnitOfMeasureDefault unitOfMeasure="W" digits="6" decimal="3" unitOfMeasureSystem="umsEnglish"/>
+			<UnitOfMeasureDefault unitOfMeasure="W" digits="6" decimal="3" unitOfMeasureSystem="umsMetric"/>
+			<UnitOfMeasureDefault unitOfMeasure="W" digits="6" decimal="3" unitOfMeasureSystem="umsImperial"/>
+			<UnitDimensionRef unitDimension="utPower"/>
+			<Name locale="en" description="Engine Power">Engine Power</Name>
+		</NumericRepresentation>
+		<NumericRepresentation domainID="vrElectricalPowerSetPoint" domainTag="560" digits="6" decimal="3">
+			<RelatedDDI ddi="568" unitOfMeasure="kg" resolution="1" offset="0" isDefaultRepresentationForDDI="true"/>
+			<UnitOfMeasureDefault unitOfMeasure="W" digits="6" decimal="3" unitOfMeasureSystem="umsEnglish"/>
+			<UnitOfMeasureDefault unitOfMeasure="W" digits="6" decimal="3" unitOfMeasureSystem="umsMetric"/>
+			<UnitOfMeasureDefault unitOfMeasure="W" digits="6" decimal="3" unitOfMeasureSystem="umsImperial"/>
+			<UnitDimensionRef unitDimension="utPower"/>
+			<Name locale="en" description="Electrical Power Setpoint">Setpoint Electrical Power of Device Element</Name>
+		</NumericRepresentation>
+		<NumericRepresentation domainID="vrElectricalPowerActual" domainTag="561" digits="6" decimal="3">		
+			<RelatedDDI ddi="569" unitOfMeasure="kg" resolution="1" offset="0" isDefaultRepresentationForDDI="true"/>
+			<UnitOfMeasureDefault unitOfMeasure="W" digits="6" decimal="3" unitOfMeasureSystem="umsEnglish"/>
+			<UnitOfMeasureDefault unitOfMeasure="W" digits="6" decimal="3" unitOfMeasureSystem="umsMetric"/>
+			<UnitOfMeasureDefault unitOfMeasure="W" digits="6" decimal="3" unitOfMeasureSystem="umsImperial"/>
+			<UnitDimensionRef unitDimension="utPower"/>
+			<Name locale="en" description="Electrical Power Actual">Actual Electrical Power of Device Element</Name>
+		</NumericRepresentation>	
+		<NumericRepresentation domainID="vrPTOLoadCurrentSpeed" domainTag="562" digits="3" decimal="2">
+			<UnitOfMeasureDefault unitOfMeasure="prcnt" digits="3" decimal="2" minValue="0" maxValue="250" unitOfMeasureSystem="umsEnglish"/>
+			<UnitOfMeasureDefault unitOfMeasure="prcnt" digits="3" decimal="2" minValue="0" maxValue="250" unitOfMeasureSystem="umsMetric"/>
+			<UnitOfMeasureDefault unitOfMeasure="prcnt" digits="3" decimal="2" minValue="0" maxValue="250" unitOfMeasureSystem="umsImperial"/>
+			<UnitDimensionRef unitDimension="utPercent"/>
+			<Name locale="en" description="PTO Load at Current Speed">The ratio of actual PTO (Power Take-Off) percent torque (indicated) to maximum indicated torque available at the current PTO speed.</Name>
+		</NumericRepresentation>
+		<NumericRepresentation domainID="vrTransmissionLoadCurrentSpeed" domainTag="563" digits="3" decimal="2">
+			<UnitOfMeasureDefault unitOfMeasure="prcnt" digits="3" decimal="2" minValue="0" maxValue="250" unitOfMeasureSystem="umsEnglish"/>
+			<UnitOfMeasureDefault unitOfMeasure="prcnt" digits="3" decimal="2" minValue="0" maxValue="250" unitOfMeasureSystem="umsMetric"/>
+			<UnitOfMeasureDefault unitOfMeasure="prcnt" digits="3" decimal="2" minValue="0" maxValue="250" unitOfMeasureSystem="umsImperial"/>
+			<UnitDimensionRef unitDimension="utPercent"/>
+			<Name locale="en" description="Transmission Load at Current Speed">The ratio of actual Transmission percent torque (indicated) to maximum indicated torque available at the current Transmission speed.</Name>
+		</NumericRepresentation>
+		<NumericRepresentation domainID="vrFuelTotalConsumptionEffective" domainTag="564" digits="5" decimal="0">		
+			<RelatedDDI ddi="316" unitOfMeasure="ml" resolution="1" offset="0" isDefaultRepresentationForDDI="true"/>
+			<UnitOfMeasureDefault unitOfMeasure="l" digits="5" decimal="0" minValue="0" maxValue="99999" unitOfMeasureSystem="umsMetric"/>
+			<UnitOfMeasureDefault unitOfMeasure="gal" digits="5" decimal="0" minValue="0" maxValue="99999" unitOfMeasureSystem="umsEnglish"/>
+			<UnitOfMeasureDefault unitOfMeasure="igal" digits="5" decimal="0" minValue="0" maxValue="99999" unitOfMeasureSystem="umsImperial"/>
+			<UnitDimensionRef unitDimension="utVolume"/>
+			<Name locale="en" description="Fuel Total Consumption Effective">Accumulated total fuel consumption in working position.</Name>
+		</NumericRepresentation>
+		<NumericRepresentation domainID="vrFuelTotalConsumptionIneffective" domainTag="565" digits="5" decimal="0">		
+			<RelatedDDI ddi="317" unitOfMeasure="ml" resolution="1" offset="0" isDefaultRepresentationForDDI="true"/>
+			<UnitOfMeasureDefault unitOfMeasure="l" digits="5" decimal="0" minValue="0" maxValue="99999" unitOfMeasureSystem="umsMetric"/>
+			<UnitOfMeasureDefault unitOfMeasure="gal" digits="5" decimal="0" minValue="0" maxValue="99999" unitOfMeasureSystem="umsEnglish"/>
+			<UnitOfMeasureDefault unitOfMeasure="igal" digits="5" decimal="0" minValue="0" maxValue="99999" unitOfMeasureSystem="umsImperial"/>
+			<UnitDimensionRef unitDimension="utVolume"/>
+			<Name locale="en" description="Fuel Total Consumption Ineffective">Accumulated total fuel consumption in non working position.</Name>
+		</NumericRepresentation>
+		<NumericRepresentation domainID="vrSlipCurrentSpeed" domainTag="566" digits="3" decimal="2">
+			<UnitOfMeasureDefault unitOfMeasure="prcnt" digits="3" decimal="2" minValue="0" maxValue="250" unitOfMeasureSystem="umsEnglish"/>
+			<UnitOfMeasureDefault unitOfMeasure="prcnt" digits="3" decimal="2" minValue="0" maxValue="250" unitOfMeasureSystem="umsMetric"/>
+			<UnitOfMeasureDefault unitOfMeasure="prcnt" digits="3" decimal="2" minValue="0" maxValue="250" unitOfMeasureSystem="umsImperial"/>
+			<UnitDimensionRef unitDimension="utPercent"/>
+			<Name locale="en" description="Slip at Current Speed">Slip at Current Speed</Name>
+		</NumericRepresentation>
 		<EnumeratedRepresentation domainID="dtApplicationMethod" domainTag="1001" attributeID="196" domainIDShort="Applicat">
 			<Name locale="en" description="ApplicationMethod">ApplicationMethod</Name>
 			<Name locale="de" description="Ausbringmethode">Ausbringmethode</Name>


### PR DESCRIPTION
Adding
vrEnginePower,
vrElectricalPowerSetPoint,
vrElectricalPowerActual,
vrPTOLoadCurrentSpeed,
vrTransmissionLoadCurrentSpeed,
vrFuelTotalConsumptionEffective,
vrFuelTotalConsumptionIneffective,
vrSlipCurrentSpeed
vrFuelProductivityTotal

Fixes #147 