### PR TITLE
Moving Prescription default rates to RxProductLookup

### DIFF
--- a/source/ADAPT/Prescriptions/RxProductLookup.cs
+++ b/source/ADAPT/Prescriptions/RxProductLookup.cs
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
   * Copyright (C) 2015 AgGateway and ADAPT Contributors
   * Copyright (C) 2015 Deere and Company
   * All rights reserved. This program and the accompanying materials
@@ -8,6 +8,7 @@
   *
   * Contributors:
   *    Tim Shearouse - initial API and implementation
+  *    Kelly Nelson - adding OutOfFieldRate and LossOfGpsRate
   *******************************************************************************/
 
 using AgGateway.ADAPT.ApplicationDataModel.Common;
@@ -29,5 +30,15 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Prescriptions
         public NumericRepresentation Representation { get; set; }
         
         public UnitOfMeasure UnitOfMeasure { get; set; }
+
+        /// <summary>
+        /// The rate to use for this product when the implement is outside the defined area
+        /// </summary>
+        public NumericRepresentationValue OutOfFieldRate { get; set; }
+
+        /// <summary>
+        /// The default rate to use for this product should the implement lose GPS signal
+        /// </summary>
+        public NumericRepresentationValue LossOfGpsRate { get; set; }
     }
 }

--- a/source/ADAPT/Prescriptions/SpatialPrescription.cs
+++ b/source/ADAPT/Prescriptions/SpatialPrescription.cs
@@ -1,4 +1,4 @@
-﻿/*******************************************************************************
+/*******************************************************************************
   * Copyright (C) 2015 AgGateway and ADAPT Contributors
   * Copyright (C) 2015 Deere and Company
   * All rights reserved. This program and the accompanying materials
@@ -8,10 +8,12 @@
   *
   * Contributors:
   *    Justin Sliekers - initial API and implementation
+  *    Kelly Nelson - Marking default rates obsolete in favor of per-product default rates
   *******************************************************************************/
 
 using AgGateway.ADAPT.ApplicationDataModel.Representations;
 using AgGateway.ADAPT.ApplicationDataModel.Shapes;
+using System;
 
 namespace AgGateway.ADAPT.ApplicationDataModel.Prescriptions
 {
@@ -19,8 +21,10 @@ namespace AgGateway.ADAPT.ApplicationDataModel.Prescriptions
     {
         public BoundingBox BoundingBox { get; set; }
 
+        [Obsolete("Set out of field rates on each RxProductLookup")]
         public NumericRepresentationValue OutOfFieldRate { get; set; }
 
+        [Obsolete("Set loss of GPS rates on each RxProductLookup")]
         public NumericRepresentationValue LossOfGpsRate { get; set; }
     }
 }


### PR DESCRIPTION
It is unclear why the default Rx rates (loss of gps & out of field) were per-Rx and not per-product since a rate requires an associated product (as implemented in RxRate).  Marking the SpatialPrescription properties readonly to avoid a breaking change.