### PR TITLE
Remove incorrect RelatedDDI under vrDistanceTraveled

### DIFF
--- a/source/Representation/Resources/RepresentationSystem.xml
+++ b/source/Representation/Resources/RepresentationSystem.xml
@@ -3534,7 +3534,7 @@
 			<Name locale="vi" description="Kinh độ">Kinh độ</Name>
 		</NumericRepresentation>
 		<NumericRepresentation domainID="vrDistanceTraveled" domainTag="78" digits="5" decimal="2">
-			<RelatedDDI ddi="117" unitOfMeasure="mm" resolution="1.00E-03" offset="0"/>
+      <!--Removed RelatedDDI 117 as that is cumulative where vrDistanceTraveled is a delta-->
 			<UnitOfMeasureDefault unitOfMeasure="ft" digits="5" decimal="2" minValue="0" maxValue="999999.99" unitOfMeasureSystem="umsEnglish"/>
 			<UnitOfMeasureDefault unitOfMeasure="m" digits="5" decimal="2" minValue="0" maxValue="999999.99" unitOfMeasureSystem="umsMetric"/>
 			<UnitOfMeasureDefault unitOfMeasure="ft" digits="5" decimal="2" minValue="0" maxValue="999999.99" unitOfMeasureSystem="umsImperial"/>


### PR DESCRIPTION
Remove the RelatedDDI element under vrDistanceTraveled that was connecting it to ISO DDI 117 because the ISO DDI is cumulative and vrDistanceTraveled is supposed to be a delta.  This was causing wrong values for vrDistanceTraveled to come out of the ISOv4Plugin.
